### PR TITLE
fix: Support addon ids with the `<scope>@<name>` format

### DIFF
--- a/src/stores/firefox-addon-store.ts
+++ b/src/stores/firefox-addon-store.ts
@@ -82,6 +82,7 @@ export class FirefoxAddonStore {
    */
   private get wrappedExtensionId(): string {
     let id = this.options.extensionId;
+    if (id.includes('@')) return id;
     if (!id.startsWith('{')) id = '{' + id;
     if (!id.endsWith('}')) id += '}';
     return id;


### PR DESCRIPTION
Firefox's extensions may have an ID in the format `<scope>@<name>`. In which case, the ID should not be wrapped in `{...}`.

Minimal proof:
```javascript
#!/usr/bin/env zx

const jwt = require('jsonwebtoken')

const issuedAt = Math.floor(Date.now() / 1000);
const payload = {
  iss: '<issuer>', // Add your jwt issuer
  jti: Math.random().toString(),
  iat: issuedAt,
  exp: issuedAt + 30,
};
const secret = '<secret>' // Add your jwt secret
const jwtBlob = jwt.sign(payload, secret, { algorithm: 'HS256' });

const jwtHeader = `JWT ${jwtBlob}`
const extId = '<your addon id>' // Add your addon id with `<scope>@<name>` fromat

const url = `https://addons.mozilla.org/api/v5/addons/addon/${extId}`

const res = await fetch(url, {
  headers: {
    Authorization: jwtHeader,
  },
});

console.log('res code:', res.status)
if (res.status === 200) {
  const json = await res.json()
  console.log('JSON:', json)
}
```