### PR TITLE
fix(init): Trim whitespace

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -52,7 +52,7 @@ async function prompt<T>(
   options: Parameters<typeof consola.prompt>[1],
   previousValue?: any,
 ): Promise<T> {
-  const result = await consola.prompt(message, {
+  let result = await consola.prompt(message, {
     default: previousValue,
     placeholder: previousValue,
     ...options,
@@ -60,6 +60,9 @@ async function prompt<T>(
   // When canceling, a symbol is returned instead of the value.
   if (typeof result === 'symbol') {
     throw Error('Canceled');
+  }
+  if (typeof result === 'string') {
+    result = result.trim();
   }
   return result as T;
 }


### PR DESCRIPTION
I was trying to do the init workflow and noticed that the Chrome Client ID I gave
the prompt ended up being parsed with white spaces prefixing it on Ghostty. Not absolutely
sure if this is an issue with consola, ghostty or the CLI itself but this PR tries to remediate
that by simply trimming all outputs from the `prompt` function that have their `typeof` as string.
