### PR TITLE
fix (edge)!: Drop support for v1.0 API authentication

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,10 @@
 name: Validate
-on: [push, workflow_call, pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   verify:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,7 +26,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -48,26 +47,4 @@ jobs:
           EDGE_API_VERSION: '1.1'
           EDGE_CLIENT_ID: ${{ secrets.TEST_EDGE_CLIENT_ID_1_1 }}
           EDGE_API_KEY: ${{ secrets.TEST_EDGE_API_KEY }}
-          EDGE_SKIP_SUBMIT_REVIEW: 'true'
-
-  e2e-test-edge-1_0:
-    name: E2E Publish Test (Edge v1.0)
-    runs-on: ubuntu-22.04
-    # If PR is from a fork, secrets aren't available, so skip this job.
-    if: github.event.pull_request.head.repo.fork != true
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-      - run: pnpm install
-      - run: ./scripts/dev.sh edge
-        env:
-          EDGE_PRODUCT_ID: ${{ secrets.TEST_EDGE_PRODUCT_ID }}
-          EDGE_CLIENT_ID: ${{ secrets.TEST_EDGE_CLIENT_ID_1_0 }}
-          EDGE_CLIENT_SECRET: ${{ secrets.TEST_EDGE_CLIENT_SECRET }}
-          EDGE_ACCESS_TOKEN_URL: ${{ secrets.TEST_EDGE_ACCESS_TOKEN_URL }}
           EDGE_SKIP_SUBMIT_REVIEW: 'true'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,7 +44,6 @@ jobs:
           FIREFOX_JWT_SECRET: ${{ secrets.TEST_FIREFOX_JWT_SECRET }}
           FIREFOX_CHANNEL: unlisted
           EDGE_PRODUCT_ID: ${{ secrets.TEST_EDGE_PRODUCT_ID }}
-          EDGE_API_VERSION: '1.1'
-          EDGE_CLIENT_ID: ${{ secrets.TEST_EDGE_CLIENT_ID_1_1 }}
+          EDGE_CLIENT_ID: ${{ secrets.TEST_EDGE_CLIENT_ID }}
           EDGE_API_KEY: ${{ secrets.TEST_EDGE_API_KEY }}
           EDGE_SKIP_SUBMIT_REVIEW: 'true'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,8 +7,8 @@ on:
       - main
 
 jobs:
-  verify:
-    name: Verify Code
+  checks:
+    name: Checks
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -23,8 +23,8 @@ jobs:
       - run: pnpm test
       - run: node bin/publish-extension.cjs --help
 
-  e2e-test:
-    name: E2E Publish Test
+  e2e-tests:
+    name: E2E Tests
     runs-on: ubuntu-22.04
     # If PR is from a fork, secrets aren't available, so skip this job.
     if: github.event.pull_request.head.repo.fork != true

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -105,9 +105,6 @@ cli.option(
 );
 
 function configFromFlags(flags: any): InlineConfig {
-  if (flags.edgeClientSecret || flags.edgeAccessTokenUrl) {
-    throw Error();
-  }
   return {
     dryRun: flags.dryRun,
     chrome: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,7 +85,7 @@ cli.option(
 );
 cli.option(
   '--edge-api-version [edgeApiVersion]',
-  'API version (1.0 or 1.1) to use',
+  'API version (1.0 or 1.1) to use (DEPRECATED: 1.0 is no longer available, so 1.1 is always used)',
 );
 cli.option(
   '--edge-api-key [edgeApiKey]',
@@ -93,11 +93,11 @@ cli.option(
 );
 cli.option(
   '--edge-client-secret [edgeClientSecret]',
-  'Client secret used for authorizing requests to Microsofts addon API v1.0',
+  'DEPRECATED: Client secret used for authorizing requests to Microsofts addon API v1.0 (no longer available)',
 );
 cli.option(
   '--edge-access-token-url [edgeAccessTokenUrl]',
-  'Access token URL used for authorizing requests to Microsofts addon API v1.0',
+  'DEPRECATED: Access token URL used for authorizing requests to Microsofts addon API v1.0 (no longer available)',
 );
 cli.option(
   '--edge-skip-submit-review',
@@ -105,6 +105,9 @@ cli.option(
 );
 
 function configFromFlags(flags: any): InlineConfig {
+  if (flags.edgeClientSecret || flags.edgeAccessTokenUrl) {
+    throw Error();
+  }
   return {
     dryRun: flags.dryRun,
     chrome: {
@@ -130,7 +133,6 @@ function configFromFlags(flags: any): InlineConfig {
       zip: flags.edgeZip,
       productId: flags.edgeProductId,
       clientId: flags.edgeClientId,
-      apiVersion: flags.edgeApiVersion,
       apiKey: flags.edgeApiKey,
       clientSecret: flags.edgeClientSecret,
       accessTokenUrl: flags.edgeAccessTokenUrl,

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -44,7 +44,8 @@ describe('resolveConfig', () => {
         productId: 'productId',
         clientId: 'clientId',
         apiKey: 'apiKey',
-        apiVersion: '1.1',
+        accessTokenUrl: 'accessTokenUrl',
+        clientSecret: 'clientSecret',
         skipSubmitReview: true,
         zip: 'zip',
       },
@@ -85,7 +86,8 @@ describe('resolveConfig', () => {
     process.env.EDGE_PRODUCT_ID = 'EDGE_PRODUCT_ID';
     process.env.EDGE_CLIENT_ID = 'EDGE_CLIENT_ID';
     process.env.EDGE_API_KEY = 'EDGE_API_KEY';
-    process.env.EDGE_API_VERSION = '1.1';
+    process.env.EDGE_CLIENT_SECRET = 'EDGE_CLIENT_SECRET';
+    process.env.EDGE_ACCESS_TOKEN_URL = 'EDGE_ACCESS_TOKEN_URL';
     const edgeSkipSubmitReview = true;
     process.env.EDGE_SKIP_SUBMIT_REVIEW = String(edgeSkipSubmitReview);
 
@@ -115,37 +117,8 @@ describe('resolveConfig', () => {
         productId: process.env.EDGE_PRODUCT_ID,
         clientId: process.env.EDGE_CLIENT_ID,
         apiKey: process.env.EDGE_API_KEY,
-        apiVersion: process.env.EDGE_API_VERSION,
-        skipSubmitReview: edgeSkipSubmitReview,
-      },
-    };
-
-    const actual = resolveConfig({});
-    expect(actual).toEqual(expected);
-  });
-
-  it('should support deprecated Edge API config', () => {
-    const dryRun = true;
-    process.env.DRY_RUN = String(dryRun);
-
-    process.env.EDGE_ZIP = 'EDGE_ZIP';
-    process.env.EDGE_PRODUCT_ID = 'EDGE_PRODUCT_ID';
-    process.env.EDGE_CLIENT_ID = 'EDGE_CLIENT_ID';
-    process.env.EDGE_CLIENT_SECRET = 'EDGE_CLIENT_SECRET';
-    process.env.EDGE_ACCESS_TOKEN_URL = 'EDGE_ACCESS_TOKEN_URL';
-    // process.env.EDGE_API_VERSION = '1.0'; // Not set, should default to 1.0
-    const edgeSkipSubmitReview = true;
-    process.env.EDGE_SKIP_SUBMIT_REVIEW = String(edgeSkipSubmitReview);
-
-    const expected: InternalConfig = {
-      dryRun,
-      edge: {
-        zip: process.env.EDGE_ZIP,
-        productId: process.env.EDGE_PRODUCT_ID,
-        clientId: process.env.EDGE_CLIENT_ID,
-        clientSecret: process.env.EDGE_CLIENT_SECRET,
         accessTokenUrl: process.env.EDGE_ACCESS_TOKEN_URL,
-        apiVersion: '1.0',
+        clientSecret: process.env.EDGE_CLIENT_SECRET,
         skipSubmitReview: edgeSkipSubmitReview,
       },
     };
@@ -196,7 +169,6 @@ describe('resolveConfig', () => {
       },
       edge: {
         ...config.edge,
-        apiVersion: '1.0',
         skipSubmitReview: false,
       },
     };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { ChromeWebStoreOptions } from './chrome';
-import { EdgeAddonStoreOptions, EdgeAddonStoreOptionsStrict } from './edge';
+import { EdgeAddonStoreOptions } from './edge';
 import { FirefoxAddonStoreOptions } from './firefox';
 import { DeepPartial } from './utils/types';
 
@@ -72,8 +72,6 @@ export function resolveConfig(
             zip: edgeZip,
             productId: config.edge?.productId ?? stringEnv('EDGE_PRODUCT_ID'),
             clientId: config.edge?.clientId ?? stringEnv('EDGE_CLIENT_ID'),
-            apiVersion:
-              config.edge?.apiVersion ?? stringEnv('EDGE_API_VERSION') ?? '1.0',
             apiKey: config.edge?.apiKey ?? stringEnv('EDGE_API_KEY'),
             clientSecret:
               config.edge?.clientSecret ?? stringEnv('EDGE_CLIENT_SECRET'),
@@ -147,7 +145,7 @@ export const InternalConfig = z.object({
   dryRun: z.boolean(),
   chrome: ChromeWebStoreOptions.optional(),
   firefox: FirefoxAddonStoreOptions.optional(),
-  edge: EdgeAddonStoreOptionsStrict.optional(),
+  edge: EdgeAddonStoreOptions.optional(),
 });
 export type InternalConfig = z.infer<typeof InternalConfig>;
 
@@ -179,7 +177,6 @@ interface CustomEnv {
   /** @deprecated since Edge API v1.1 release */
   EDGE_ACCESS_TOKEN_URL: string | undefined;
   EDGE_API_KEY: string | undefined;
-  EDGE_API_VERSION: '1.0' | '1.1' | undefined;
   EDGE_SKIP_SUBMIT_REVIEW: string | undefined;
 }
 

--- a/src/edge/edge-addon-store.ts
+++ b/src/edge/edge-addon-store.ts
@@ -5,40 +5,19 @@ import { Store } from '../utils/store';
 import { z } from 'zod';
 import { ensureZipExists } from '../utils/fs';
 
-const EdgeAddonBaseOptions = z.object({
+export const EdgeAddonStoreOptions = z.object({
   zip: z.string().min(1),
   productId: z.string().min(1).trim(),
   clientId: z.string().min(1).trim(),
   skipSubmitReview: z.boolean().default(false),
-});
-
-const EdgeAddonStore1_0Options = {
-  apiVersion: z.literal('1.0').default('1.0'),
-  clientSecret: z.string().min(1).trim(),
-  accessTokenUrl: z.string().min(1).trim(),
-};
-const EdgeAddonStore1_1Options = {
-  apiVersion: z.literal('1.1'),
   apiKey: z.string().min(1).trim(),
-};
-
-export const EdgeAddonStoreOptions = EdgeAddonBaseOptions.extend({
-  ...EdgeAddonStore1_0Options,
-  ...EdgeAddonStore1_1Options,
-  apiVersion: z.enum(['1.0', '1.1']).default('1.0'),
+  /** @deprecated: API v1.0 authorization field no longer in use. */
+  clientSecret: z.string(),
+  /** @deprecated: API v1.0 authorization field no longer in use. */
+  accessTokenUrl: z.string(),
 });
 
-// Zod does not support calling .partial() on discriminated unions, so we have
-// to create two types. One containing all options and one discriminated union
-// between versions.
-export const EdgeAddonStoreOptionsStrict = EdgeAddonBaseOptions.and(
-  z.discriminatedUnion('apiVersion', [
-    z.object(EdgeAddonStore1_0Options),
-    z.object(EdgeAddonStore1_1Options),
-  ]),
-);
-
-export type EdgeAddonStoreOptions = z.infer<typeof EdgeAddonStoreOptionsStrict>;
+export type EdgeAddonStoreOptions = z.infer<typeof EdgeAddonStoreOptions>;
 
 export class EdgeAddonStore implements Store {
   private api: EdgeApi;

--- a/src/edge/edge-addon-store.ts
+++ b/src/edge/edge-addon-store.ts
@@ -12,9 +12,9 @@ export const EdgeAddonStoreOptions = z.object({
   skipSubmitReview: z.boolean().default(false),
   apiKey: z.string().min(1).trim(),
   /** @deprecated: API v1.0 authorization field no longer in use. */
-  clientSecret: z.string(),
+  clientSecret: z.string().optional(),
   /** @deprecated: API v1.0 authorization field no longer in use. */
-  accessTokenUrl: z.string(),
+  accessTokenUrl: z.string().optional(),
 });
 
 export type EdgeAddonStoreOptions = z.infer<typeof EdgeAddonStoreOptions>;

--- a/src/edge/edge-api.ts
+++ b/src/edge/edge-api.ts
@@ -4,17 +4,8 @@ import { fetch } from '../utils/fetch';
 export type EdgeApiOptions = {
   productId: string;
   clientId: string;
-} & (
-  | {
-      apiVersion: '1.0';
-      clientSecret: string;
-      accessTokenUrl: string;
-    }
-  | {
-      apiVersion: '1.1';
-      apiKey: string;
-    }
-);
+  apiKey: string;
+};
 
 export interface EdgeTokenDetails {
   access_token: string;
@@ -46,30 +37,10 @@ export class EdgeApi {
    * Docs: https://learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/publish/api/using-addons-api#sample-request
    */
   getToken(): Promise<EdgeTokenDetails> {
-    // Edge API requires an API key instead of an access token since version 1.1
-    if (this.options.apiVersion !== '1.0') {
-      return Promise.resolve({
-        access_token: this.options.apiKey,
-        expires_in: 0,
-        token_type: 'ApiKey',
-      });
-    }
-
-    const form = new URLSearchParams();
-    form.set('client_id', this.options.clientId);
-    form.set(
-      'scope',
-      'https://api.addons.microsoftedge.microsoft.com/.default',
-    );
-    form.set('client_secret', this.options.clientSecret);
-    form.set('grant_type', 'client_credentials');
-
-    return fetch(this.options.accessTokenUrl, {
-      method: 'POST',
-      body: form,
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
+    return Promise.resolve({
+      access_token: this.options.apiKey,
+      expires_in: 0,
+      token_type: 'ApiKey',
     });
   }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -262,43 +262,13 @@ async function initEdge(
     previousOptions?.clientId,
   );
   entries.push(['EDGE_CLIENT_ID', clientId]);
-  const apiVersion = await prompt<string>(
-    'Enter the API version you will use:',
-    {
-      type: 'select',
-      options: ['1.1', '1.0'],
-    },
-    previousOptions?.apiVersion,
-  );
-  entries.push(['EDGE_API_VERSION', apiVersion]);
 
-  if (apiVersion === '1.1') {
-    const apiKey = await prompt<string>(
-      'Enter your API key:',
-      { type: 'text' },
-      previousOptions?.apiVersion === '1.1'
-        ? previousOptions.apiKey
-        : undefined,
-    );
-    entries.push(['EDGE_API_KEY', apiKey]);
-  } else {
-    const clientSecret = await prompt<string>(
-      'Enter your client secret:',
-      { type: 'text' },
-      previousOptions?.apiVersion === '1.0'
-        ? previousOptions?.clientSecret
-        : undefined,
-    );
-    const accessTokenUrl = await prompt<string>(
-      'Enter your access token URL:',
-      { type: 'text' },
-      previousOptions?.apiVersion === '1.0'
-        ? previousOptions?.accessTokenUrl
-        : undefined,
-    );
-    entries.push(['EDGE_CLIENT_SECRET', clientSecret]);
-    entries.push(['EDGE_ACCESS_TOKEN_URL', accessTokenUrl]);
-  }
+  const apiKey = await prompt<string>(
+    'Enter your API key:',
+    { type: 'text' },
+    previousOptions?.apiKey,
+  );
+  entries.push(['EDGE_API_KEY', apiKey]);
 
   const submitForReview = await prompt<boolean>(
     'When uploading, automatically submit new update for review?',

--- a/src/submit.ts
+++ b/src/submit.ts
@@ -17,19 +17,22 @@ export async function submit(config: InlineConfig): Promise<SubmitResults> {
     consola.warn('Dry run, skipping submission');
   }
 
-  if (internalConfig.edge?.apiVersion === '1.0') {
+  if (
+    internalConfig.edge?.clientSecret ||
+    internalConfig.edge?.accessTokenUrl
+  ) {
     consola.warn(
       [
-        'Edge API v1.0 will stop working Jan 1, 2025. To upgrade to v1.1:',
-        '  1. Pass the new CLI flag (`--edge-api-version 1.1`) or set the environment variable (`EDGE_API_VERSION=1.1`) to opt into the new version',
-        '  2. Replace the client secret/access token URL with an API key (`--edge-api-key` flag or `EDGE_API_KEY` environment variable)',
-        '  3. Stop passing in a client secret and access token URL',
-        'Or run `publish-extension init` and re-initialize the edge store for API v1.1.',
+        'Edge API v1.0 was deprecated Jan 1, 2025. v1.1 of the API requires different authentication. To upgrade:',
+        '  1. Remove the `--edge-client-secret` or `EDGE_CLIENT_SECRET` environment variable',
+        '  2. Remove the `--edge-access-token-url` or `EDGE_ACCESS_TOKEN_URL` environment variable',
+        '  3. Follow the instructions below to add the `--edge-api-key` flag or `EDGE_API_KEY` environment variable',
+        'Or run `publish-extension init` and re-initialize the edge store.',
         '',
         'To generate an API key:',
-        '1. Visit https://partner.microsoft.com/en-us/dashboard/microsoftedge/publishapi',
-        '2. Enable the v1.1 API if necessary.',
-        '3. Create an new API key',
+        '  1. Visit https://partner.microsoft.com/en-us/dashboard/microsoftedge/publishapi',
+        '  2. Enable the v1.1 API if necessary',
+        '  3. Create an new API key',
         '',
         'Refer to Microsoft API reference for more details: https://learn.microsoft.com/en-us/microsoft-edge/extensions-chromium/publish/api/using-addons-api?tabs=v1-1#overview-of-using-the-update-rest-api',
       ].join('\n'),


### PR DESCRIPTION
The v1.0 auth has shut down, so I'm removing that code. Run `publish-extension init` (or `wxt submit init` if you're using WXT) and select the edge store to generate new auth.