### PR TITLE
feat: add Opera support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@ https://github.com/aklinker1/publish-browser-extension/assets/10101283/b0e856ca-
 
 ## Features
 
-- Publish to the **Chrome Web Store**, **Firefox Addon Store**, and **Edge Addon Store**
+- Publish to the following stores:
+  - [Chrome](https://developer.chrome.com/docs/webstore)
+  - [Edge](https://microsoftedge.microsoft.com/addons/Microsoft-Edge-Extensions-Home)
+  - [Firefox](https://addons.mozilla.org/en-US/firefox/extensions/)
+  - [Opera](https://addons.opera.com/developer/)
+
 - Helper script to generate secrets and configure options
 - **Upload sources ZIP** to the Firefox Addon Store
 
@@ -37,7 +42,8 @@ Then, just run the submit command, passing the ZIP files you want to submit:
 publish-extension \
   --chrome-zip dist/chrome.zip \
   --firefox-zip dist/firefox.zip --firefox-sources-zip dist/sources.zip \
-  --edge-zip dist/chrome.zip
+  --edge-zip dist/chrome.zip \
+  --opera-zip dist/opera.zip
 ```
 
 `publish-extension` will automatically look for a `.env.submit` file and load it if it exists.
@@ -69,10 +75,15 @@ publishExtension({
   },
   edge: {
     zip: 'dist/chrome.zip',
-    productId: "<edge-product-id>",
-    clientId: "<edge-client-id>",
-    apiKey: "<edge-api-key>",
+    productId: '<edge-product-id>',
+    clientId: '<edge-client-id>',
+    apiKey: '<edge-api-key>',
     skipSubmitReview: false,
+  },
+  opera: {
+    zip: 'dist/opera.zip',
+    packageId: '<opera-package-id>',
+    sessionId: '<opera-session-id>',
   },
 })
   .then(results => console.log(results))
@@ -105,4 +116,5 @@ publishExtension({
    bun dev:chrome
    bun dev:firefox
    bun dev:edge
+   bun dev:opera
    ```

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev:chrome": "bun ./scripts/dev.mjs chrome",
     "dev:firefox": "bun ./scripts/dev.mjs firefox",
     "dev:edge": "bun ./scripts/dev.mjs edge",
+    "dev:opera": "bun ./scripts/dev.mjs opera",
     "dev:help": "bun ./scripts/dev.mjs help",
     "publish-extension": "bun src/cli.ts",
     "prepack": "bun run build",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -30,6 +30,8 @@ try {
         'extension/firefox.zip',
         '--edge-zip',
         'extension/chrome.zip',
+        '--opera-zip',
+        'extension/chrome.zip',
       ]);
       break;
 
@@ -50,10 +52,14 @@ try {
       publish(['--edge-zip', 'extension/chrome.zip']);
       break;
 
+    case 'opera':
+      publish(['--opera-zip', 'extension/chrome.zip']);
+      break;
+
     default:
       console.log();
       console.log(
-        "Run 'bun dev:chrome' or 'bun dev:firefox' or 'bun dev:edge' or 'bun dev:all'",
+        "Run 'bun dev:chrome' or 'bun dev:firefox' or 'bun dev:edge' or 'bun dev:opera' or 'bun dev:all'",
       );
       publish();
       break;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -109,14 +109,6 @@ cli.option(
   '--opera-session-id [sessionId]',
   'Session ID used for authorizing requests to Opera Addons API',
 );
-cli.option(
-  '--opera-ingress-cookie-api [ingressCookieApi]',
-  'Ingress Cookie API used for authorizing requests to Opera Addons API',
-);
-cli.option(
-  '--opera-csrftoken [csrftoken]',
-  'X-CSRFToken used for authorizing requests to Opera Addons API',
-);
 
 function configFromFlags(flags: any): InlineConfig {
   return {
@@ -153,8 +145,6 @@ function configFromFlags(flags: any): InlineConfig {
       zip: flags.operaZip,
       packageId: flags.packageId,
       sessionId: flags.sessionId,
-      ingressCookieApi: flags.ingressCookieApi,
-      csrftoken: flags.csrftoken,
     },
   };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -109,6 +109,10 @@ cli.option(
   '--opera-session-id [sessionId]',
   'Session ID used for authorizing requests to Opera Addons API',
 );
+cli.option(
+  '--opera-skip-submit-review',
+  "Just upload the extension zip, don't submit it for review or publish it",
+);
 
 function configFromFlags(flags: any): InlineConfig {
   return {
@@ -143,8 +147,9 @@ function configFromFlags(flags: any): InlineConfig {
     },
     opera: {
       zip: flags.operaZip,
-      packageId: flags.packageId,
-      sessionId: flags.sessionId,
+      packageId: flags.operaPackageId,
+      sessionId: flags.operaSessionId,
+      skipSubmitReview: flags.operaSkipSubmitReview,
     },
   };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -99,6 +99,24 @@ cli.option(
   '--edge-skip-submit-review',
   "Just upload the extension zip, don't submit it for review or publish it",
 );
+// Opera
+cli.option('--opera-zip [operaZip]', 'Path to extension zip to upload');
+cli.option(
+  '--opera-package-id [packageId]',
+  'Package ID listed in the package developer URL: https://addons.opera.com/developer/package/<packageId>',
+);
+cli.option(
+  '--opera-session-id [sessionId]',
+  'Session ID used for authorizing requests to Opera Addons API',
+);
+cli.option(
+  '--opera-ingress-cookie-api [ingressCookieApi]',
+  'Ingress Cookie API used for authorizing requests to Opera Addons API',
+);
+cli.option(
+  '--opera-csrftoken [csrftoken]',
+  'X-CSRFToken used for authorizing requests to Opera Addons API',
+);
 
 function configFromFlags(flags: any): InlineConfig {
   return {
@@ -130,6 +148,13 @@ function configFromFlags(flags: any): InlineConfig {
       clientSecret: flags.edgeClientSecret,
       accessTokenUrl: flags.edgeAccessTokenUrl,
       skipSubmitReview: flags.edgeSkipSubmitReview,
+    },
+    opera: {
+      zip: flags.operaZip,
+      packageId: flags.packageId,
+      sessionId: flags.sessionId,
+      ingressCookieApi: flags.ingressCookieApi,
+      csrftoken: flags.csrftoken,
     },
   };
 }
@@ -163,6 +188,7 @@ cli
       chromeZip: '...',
       firefoxZip: '...',
       edgeZip: '...',
+      operaZip: '...',
       ...flags,
     });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -115,6 +115,20 @@ cli.option(
 );
 
 function configFromFlags(flags: any): InlineConfig {
+  let operaPackageId: number | undefined = undefined;
+
+  if (flags.operaPackageId !== undefined) {
+    const parsed = Number(flags.operaPackageId);
+
+    if (!Number.isNaN(parsed) && Number.isInteger(parsed) && parsed > 0) {
+      operaPackageId = parsed;
+    } else {
+      consola.warn(
+        `Invalid value for --opera-package-id: "${flags.operaPackageId}". It must be a positive integer.`,
+      );
+    }
+  }
+
   return {
     dryRun: flags.dryRun,
     chrome: {
@@ -147,7 +161,7 @@ function configFromFlags(flags: any): InlineConfig {
     },
     opera: {
       zip: flags.operaZip,
-      packageId: flags.operaPackageId,
+      packageId: operaPackageId,
       sessionId: flags.operaSessionId,
       skipSubmitReview: flags.operaSkipSubmitReview,
     },

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -6,7 +6,7 @@ import {
   validateConfig,
 } from './config';
 
-const RESET_ENV_NAMES = /(^CHROME_|^FIREFOX_|^EDGE_|^DRY_RUN$)/;
+const RESET_ENV_NAMES = /(^CHROME_|^FIREFOX_|^EDGE_|^OPERA_|^DRY_RUN$)/;
 
 describe('resolveConfig', () => {
   beforeEach(() => {
@@ -48,6 +48,13 @@ describe('resolveConfig', () => {
         clientSecret: 'clientSecret',
         skipSubmitReview: true,
         zip: 'zip',
+      },
+      opera: {
+        zip: 'zip',
+        packageId: 1,
+        sessionId: 'sessionId',
+        csrftoken: 'csrftoken',
+        ingressCookieApi: 'ingressCookieApi',
       },
     } satisfies InternalConfig;
 
@@ -91,6 +98,11 @@ describe('resolveConfig', () => {
     const edgeSkipSubmitReview = true;
     process.env.EDGE_SKIP_SUBMIT_REVIEW = String(edgeSkipSubmitReview);
 
+    process.env.OPERA_ZIP = 'OPERA_ZIP';
+    process.env.OPERA_SESSION_ID = 'OPERA_SESSION_ID';
+    const operaPackageId = 1;
+    process.env.OPERA_PACKAGE_ID = String(operaPackageId);
+
     const expected: InternalConfig = {
       dryRun,
       chrome: {
@@ -120,6 +132,13 @@ describe('resolveConfig', () => {
         accessTokenUrl: process.env.EDGE_ACCESS_TOKEN_URL,
         clientSecret: process.env.EDGE_CLIENT_SECRET,
         skipSubmitReview: edgeSkipSubmitReview,
+      },
+      opera: {
+        zip: process.env.OPERA_ZIP,
+        packageId: operaPackageId,
+        sessionId: process.env.OPERA_SESSION_ID!,
+        csrftoken: process.env.OPERA_CSRFTOKEN!,
+        ingressCookieApi: process.env.OPERA_INGRESS_COOKIE_API!,
       },
     };
 
@@ -151,6 +170,13 @@ describe('resolveConfig', () => {
         apiKey: 'apiKey',
         zip: 'zip',
       },
+      opera: {
+        zip: 'zip',
+        packageId: 1,
+        sessionId: 'sessionId',
+        csrftoken: 'csrftoken',
+        ingressCookieApi: 'ingressCookieApi',
+      },
     };
 
     const expected = {
@@ -171,6 +197,10 @@ describe('resolveConfig', () => {
         ...config.edge,
         skipSubmitReview: false,
       },
+      opera: {
+        ...config.opera,
+        // No default values
+      },
     };
 
     const actual = resolveConfig(config);
@@ -178,7 +208,7 @@ describe('resolveConfig', () => {
     expect(actual).toEqual(expected);
   });
 
-  it('should exclude chrome, firefox, and edge objects when their zip option is not passed', () => {
+  it('should exclude chrome, firefox, edge and opera objects when their zip option is not passed', () => {
     const config: InlineConfig = {
       dryRun: false,
       chrome: {
@@ -190,12 +220,16 @@ describe('resolveConfig', () => {
       edge: {
         clientId: 'clientId',
       },
+      opera: {
+        packageId: 1,
+      },
     };
     const expected: InternalConfig = {
       dryRun: false,
       chrome: undefined,
       edge: undefined,
       firefox: undefined,
+      opera: undefined,
     };
 
     const actual = resolveConfig(config);

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -53,8 +53,6 @@ describe('resolveConfig', () => {
         zip: 'zip',
         packageId: 1,
         sessionId: 'sessionId',
-        csrftoken: 'csrftoken',
-        ingressCookieApi: 'ingressCookieApi',
       },
     } satisfies InternalConfig;
 
@@ -137,8 +135,6 @@ describe('resolveConfig', () => {
         zip: process.env.OPERA_ZIP,
         packageId: operaPackageId,
         sessionId: process.env.OPERA_SESSION_ID!,
-        csrftoken: process.env.OPERA_CSRFTOKEN!,
-        ingressCookieApi: process.env.OPERA_INGRESS_COOKIE_API!,
       },
     };
 
@@ -174,8 +170,6 @@ describe('resolveConfig', () => {
         zip: 'zip',
         packageId: 1,
         sessionId: 'sessionId',
-        csrftoken: 'csrftoken',
-        ingressCookieApi: 'ingressCookieApi',
       },
     };
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -174,7 +174,6 @@ describe('resolveConfig', () => {
         zip: 'zip',
         packageId: 1,
         sessionId: 'sessionId',
-        skipSubmitReview: false,
       },
     };
 
@@ -198,7 +197,7 @@ describe('resolveConfig', () => {
       },
       opera: {
         ...config.opera,
-        // No default values
+        skipSubmitReview: false,
       },
     };
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -53,6 +53,7 @@ describe('resolveConfig', () => {
         zip: 'zip',
         packageId: 1,
         sessionId: 'sessionId',
+        skipSubmitReview: true,
       },
     } satisfies InternalConfig;
 
@@ -100,6 +101,8 @@ describe('resolveConfig', () => {
     process.env.OPERA_SESSION_ID = 'OPERA_SESSION_ID';
     const operaPackageId = 1;
     process.env.OPERA_PACKAGE_ID = String(operaPackageId);
+    const operaSkipSubmitReview = true;
+    process.env.OPERA_SKIP_SUBMIT_REVIEW = String(operaSkipSubmitReview);
 
     const expected: InternalConfig = {
       dryRun,
@@ -135,6 +138,7 @@ describe('resolveConfig', () => {
         zip: process.env.OPERA_ZIP,
         packageId: operaPackageId,
         sessionId: process.env.OPERA_SESSION_ID!,
+        skipSubmitReview: operaSkipSubmitReview,
       },
     };
 
@@ -170,6 +174,7 @@ describe('resolveConfig', () => {
         zip: 'zip',
         packageId: 1,
         sessionId: 'sessionId',
+        skipSubmitReview: false,
       },
     };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,6 +91,10 @@ export function resolveConfig(
             zip: operaZip,
             packageId: config.opera?.packageId ?? intEnv('OPERA_PACKAGE_ID'),
             sessionId: config.opera?.sessionId ?? stringEnv('OPERA_SESSION_ID'),
+            skipSubmitReview:
+              config.opera?.skipSubmitReview ??
+              booleanEnv('OPERA_SKIP_SUBMIT_REVIEW') ??
+              false,
           },
   };
 }
@@ -197,6 +201,7 @@ export interface CustomEnv {
   OPERA_ZIP: string | undefined;
   OPERA_PACKAGE_ID: string | undefined;
   OPERA_SESSION_ID: string | undefined;
+  OPERA_SKIP_SUBMIT_REVIEW: string | undefined;
 }
 
 declare global {

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,10 +91,6 @@ export function resolveConfig(
             zip: operaZip,
             packageId: config.opera?.packageId ?? intEnv('OPERA_PACKAGE_ID'),
             sessionId: config.opera?.sessionId ?? stringEnv('OPERA_SESSION_ID'),
-            csrftoken: config.opera?.csrftoken ?? stringEnv('OPERA_CSRFTOKEN'),
-            ingressCookieApi:
-              config.opera?.ingressCookieApi ??
-              stringEnv('OPERA_INGRESS_COOKIE_API'),
           },
   };
 }
@@ -201,8 +197,6 @@ export interface CustomEnv {
   OPERA_ZIP: string | undefined;
   OPERA_PACKAGE_ID: string | undefined;
   OPERA_SESSION_ID: string | undefined;
-  OPERA_INGRESS_COOKIE_API: string | undefined;
-  OPERA_CSRFTOKEN: string | undefined;
 }
 
 declare global {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import { ChromeWebStoreOptions } from './chrome';
 import { EdgeAddonStoreOptions } from './edge';
 import { FirefoxAddonStoreOptions } from './firefox';
 import type { DeepPartial } from './utils/types';
+import { OperaAddonsStoreOptions } from './opera';
 
 /**
  * Given inline config, read environment variables and apply defaults. Throws an error if any config
@@ -16,6 +17,7 @@ export function resolveConfig(
   const chromeZip = config.chrome?.zip ?? stringEnv('CHROME_ZIP');
   const firefoxZip = config.firefox?.zip ?? stringEnv('FIREFOX_ZIP');
   const edgeZip = config.edge?.zip ?? stringEnv('EDGE_ZIP');
+  const operaZip = config.opera?.zip ?? stringEnv('OPERA_ZIP');
 
   return {
     dryRun,
@@ -82,6 +84,18 @@ export function resolveConfig(
               booleanEnv('EDGE_SKIP_SUBMIT_REVIEW') ??
               false,
           },
+    opera:
+      operaZip == null
+        ? undefined
+        : {
+            zip: operaZip,
+            packageId: config.opera?.packageId ?? intEnv('OPERA_PACKAGE_ID'),
+            sessionId: config.opera?.sessionId ?? stringEnv('OPERA_SESSION_ID'),
+            csrftoken: config.opera?.csrftoken ?? stringEnv('OPERA_CSRFTOKEN'),
+            ingressCookieApi:
+              config.opera?.ingressCookieApi ??
+              stringEnv('OPERA_INGRESS_COOKIE_API'),
+          },
   };
 }
 
@@ -138,6 +152,10 @@ export const InlineConfig = z.object({
    * Options for publishing to Edge.
    */
   edge: EdgeAddonStoreOptions.partial().optional(),
+  /**
+   * Options for publishing to Opera
+   */
+  opera: OperaAddonsStoreOptions.partial().optional(),
 });
 export type InlineConfig = z.infer<typeof InlineConfig>;
 
@@ -146,6 +164,7 @@ export const InternalConfig = z.object({
   chrome: ChromeWebStoreOptions.optional(),
   firefox: FirefoxAddonStoreOptions.optional(),
   edge: EdgeAddonStoreOptions.optional(),
+  opera: OperaAddonsStoreOptions.optional(),
 });
 export type InternalConfig = z.infer<typeof InternalConfig>;
 
@@ -178,6 +197,12 @@ export interface CustomEnv {
   EDGE_ACCESS_TOKEN_URL: string | undefined;
   EDGE_API_KEY: string | undefined;
   EDGE_SKIP_SUBMIT_REVIEW: string | undefined;
+
+  OPERA_ZIP: string | undefined;
+  OPERA_PACKAGE_ID: string | undefined;
+  OPERA_SESSION_ID: string | undefined;
+  OPERA_INGRESS_COOKIE_API: string | undefined;
+  OPERA_CSRFTOKEN: string | undefined;
 }
 
 declare global {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export { InlineConfig } from './config';
 export * from './firefox';
 export * from './edge';
 export * from './chrome';
+export * from './opera';

--- a/src/init.ts
+++ b/src/init.ts
@@ -267,6 +267,13 @@ async function initOpera(
   );
   entries.push(['OPERA_SESSION_ID', sessionId]);
 
+  const submitForReview = await prompt<boolean>(
+    'When uploading, automatically submit new update for review?',
+    { type: 'confirm' },
+    String(!previousOptions?.skipSubmitReview),
+  );
+  entries.push(['OPERA_SKIP_SUBMIT_REVIEW', !submitForReview]);
+
   return entries;
 }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -267,20 +267,6 @@ async function initOpera(
   );
   entries.push(['OPERA_SESSION_ID', sessionId]);
 
-  const csrftoken = await prompt<string>(
-    'Enter the CSRFToken (csrftoken):',
-    { type: 'text' },
-    previousOptions?.csrftoken,
-  );
-  entries.push(['OPERA_CSRFTOKEN', csrftoken]);
-
-  const ingressCookieApi = await prompt<string>(
-    'Enter the Ingress Cookie API (INGRESSCOOKIE_API):',
-    { type: 'text' },
-    previousOptions?.ingressCookieApi,
-  );
-  entries.push(['OPERA_INGRESS_COOKIE_API', ingressCookieApi]);
-
   return entries;
 }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -5,6 +5,7 @@ import { ChromeWebStoreOptions } from './chrome';
 import { FirefoxAddonStoreOptions } from './firefox';
 import { EdgeAddonStoreOptions } from './edge';
 import { ofetch } from 'ofetch';
+import type { OperaAddonsStoreOptions } from './opera';
 
 type Entry = [key: keyof CustomEnv, value: string | number | boolean];
 
@@ -24,6 +25,7 @@ export async function init(config: InlineConfig) {
         { value: 'chrome', label: 'Chrome Web Store' },
         { value: 'firefox', label: 'Firefox Addon Store' },
         { value: 'edge', label: 'Edge Addon Store' },
+        { value: 'opera', label: 'Opera Addons' },
       ],
       required: true,
     },
@@ -43,11 +45,14 @@ export async function init(config: InlineConfig) {
   if (stores?.includes('edge')) {
     replacements.push(...(await initEdge(previousConfig.edge)));
   }
+  if (stores?.includes('opera')) {
+    replacements.push(...(await initOpera(previousConfig.opera)));
+  }
 
   await updateEnvFile(replacements);
   console.log();
   consola.log(
-    'To submit an update, run:\n\n  `publish-extension --chrome-zip path/to/extension.zip \\`\n    `--firefox-zip path/to/extension.zip \\`\n    `--edge-zip path/to/extension.zip`',
+    'To submit an update, run:\n\n  `publish-extension --chrome-zip path/to/extension.zip \\`\n    `--firefox-zip path/to/extension.zip \\`\n    `--edge-zip path/to/extension.zip \\`\n    `--opera-zip path/to/extension.zip`',
   );
 }
 
@@ -228,6 +233,53 @@ async function initFirefox(
     previousOptions?.channel,
   );
   entries.push(['FIREFOX_CHANNEL', channel]);
+
+  return entries;
+}
+
+async function initOpera(
+  previousOptions: Partial<OperaAddonsStoreOptions> | undefined,
+): Promise<Entry[]> {
+  const entries: Entry[] = [];
+
+  console.log();
+  consola.start('Opera Addons\n');
+
+  consola.info(
+    'Your `--opera-package-id` is listed in the URL of your addon developer dashboard, example:\n' +
+      'https://addons.opera.com/developer/package/<packageId>',
+  );
+  const packageId = await prompt<number>(
+    'Enter the package ID (packageId):',
+    { type: 'text' },
+    String(previousOptions?.packageId),
+  );
+  entries.push(['OPERA_PACKAGE_ID', packageId]);
+
+  consola.info(
+    'Your `--opera-session-id`, `--opera-csrtoken` and `--opera-ingress-cookie-api` are ' +
+      'Cookies available on the Opera Addons website: https://addons.opera.com/developer/',
+  );
+  const sessionId = await prompt<string>(
+    'Enter the session ID (sessionid):',
+    { type: 'text' },
+    previousOptions?.sessionId,
+  );
+  entries.push(['OPERA_SESSION_ID', sessionId]);
+
+  const csrftoken = await prompt<string>(
+    'Enter the CSRFToken (csrftoken):',
+    { type: 'text' },
+    previousOptions?.csrftoken,
+  );
+  entries.push(['OPERA_CSRFTOKEN', csrftoken]);
+
+  const ingressCookieApi = await prompt<string>(
+    'Enter the Ingress Cookie API (INGRESSCOOKIE_API):',
+    { type: 'text' },
+    previousOptions?.ingressCookieApi,
+  );
+  entries.push(['OPERA_INGRESS_COOKIE_API', ingressCookieApi]);
 
   return entries;
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -249,16 +249,30 @@ async function initOpera(
     'Your `--opera-package-id` is listed in the URL of your addon developer dashboard, example:\n' +
       'https://addons.opera.com/developer/package/<packageId>',
   );
-  const packageId = await prompt<number>(
-    'Enter the package ID (packageId):',
-    { type: 'text' },
-    String(previousOptions?.packageId),
-  );
+
+  let packageId: number | undefined;
+  while (true) {
+    const input = await prompt<string>(
+      'Enter the package ID (packageId):',
+      { type: 'text' },
+      previousOptions?.packageId
+        ? String(previousOptions.packageId)
+        : undefined,
+    );
+
+    const parsed = Number(input.trim());
+    if (Number.isInteger(parsed) && parsed > 0) {
+      packageId = parsed;
+      break;
+    }
+
+    consola.warn('Please enter a valid positive integer for the package ID.');
+  }
   entries.push(['OPERA_PACKAGE_ID', packageId]);
 
   consola.info(
-    'Your `--opera-session-id`, `--opera-csrtoken` and `--opera-ingress-cookie-api` are ' +
-      'Cookies available on the Opera Addons website: https://addons.opera.com/developer/',
+    'Your `--opera-session-id` is the `sessionid` cookie available on the Opera Addons website: ' +
+      'https://addons.opera.com/developer/',
   );
   const sessionId = await prompt<string>(
     'Enter the session ID (sessionid):',

--- a/src/opera/index.ts
+++ b/src/opera/index.ts
@@ -1,0 +1,2 @@
+export * from './opera-api';
+export * from './opera-addons-store';

--- a/src/opera/opera-addons-store.ts
+++ b/src/opera/opera-addons-store.ts
@@ -2,11 +2,13 @@ import { z } from 'zod/v4';
 import type { Store } from '../utils/store';
 import { ensureZipExists } from '../utils/fs';
 import { OperaAddonsApi } from './opera-api';
+import { NotImplemented } from '../utils/errors';
 
 export const OperaAddonsStoreOptions = z.object({
   zip: z.string().min(1),
   packageId: z.number().min(1),
   sessionId: z.string().min(1).trim(),
+  skipSubmitReview: z.boolean().default(false),
 });
 
 export type OperaAddonsStoreOptions = z.infer<typeof OperaAddonsStoreOptions>;
@@ -64,7 +66,13 @@ export class OperaAddonsStore implements Store {
       ...creationData,
     });
 
+    if (this.options.skipSubmitReview) {
+      this.setStatus('Skipping submission (skipSubmitReview=true)');
+      return;
+    }
+
     // TODO: Submit changes
+    throw NotImplemented('auto submission');
   }
 
   async ensureZipsExist(): Promise<void> {

--- a/src/opera/opera-addons-store.ts
+++ b/src/opera/opera-addons-store.ts
@@ -2,6 +2,7 @@ import { z } from 'zod/v4';
 import type { Store } from '../utils/store';
 import { ensureZipExists } from '../utils/fs';
 import { OperaAddonsApi } from './opera-api';
+import { sleep } from '../utils/sleep';
 
 export const OperaAddonsStoreOptions = z.object({
   zip: z.string().min(1),
@@ -36,19 +37,39 @@ export class OperaAddonsStore implements Store {
     }
 
     this.setStatus(`Found ${addon.name} at ${addon.details_url}`);
+    this.setStatus('Getting previous addon version details');
+
+    const previousVersion = addon.versions[0]?.version;
+    if (!previousVersion) {
+      throw new Error(
+        'You need at least one previous version to be uploaded before uploading a new one!',
+      );
+    }
+
+    // For some reasons, when pushing a new version, Opera's API copies
+    // almost all the details from the previous version, except for the
+    // "short summary" field. So we need to copy that part ouserselves by
+    // reusing the previous version's details
+    const previousVersionDetails = await this.api.getAddonVersionDetails({
+      packageId: this.options.packageId,
+      version: previousVersion,
+    });
+
+    if ('detail' in previousVersionDetails) {
+      throw new Error(previousVersionDetails.detail);
+    }
+
+    if (!previousVersionDetails.translations.en?.short_description) {
+      throw new Error(
+        'The previous version is missing the English short description, ' +
+          'which is required to be copied to the new version.' +
+          'Please add it in Opera Developer Dashboard and try again.',
+      );
+    }
 
     if (dryRun) {
       this.setStatus('DRY RUN: Skipped upload and publishing');
       return;
-    }
-
-    this.setStatus('Getting last addon version');
-
-    const latestVersion = addon.versions[0]?.version;
-    if (!latestVersion) {
-      throw new Error(
-        'You need at least one previous version to be uploaded before uploading a new one!',
-      );
     }
 
     this.setStatus('Uploading new version from zip');
@@ -58,10 +79,18 @@ export class OperaAddonsStore implements Store {
       file: this.options.zip,
     });
 
-    this.setStatus('Waiting for validation results');
+    this.setStatus(
+      `File uploaded (fileId: ${creationData.fileId}), waiting for validation results...`,
+    );
+
+    // Their might be some delay between the upload file request finishing and
+    // the file being actually available for validation, so we need to wait a bit
+    // before sending the validation request
+    await sleep(5_000);
+
     await this.api.validateFileUpload({
       packageId: this.options.packageId,
-      lastVersion: latestVersion,
+      lastVersion: previousVersion,
       ...creationData,
     });
 
@@ -87,10 +116,35 @@ export class OperaAddonsStore implements Store {
       );
     }
 
-    await this.api.submitVersion({
+    // As said above, we need to copy the previous version short summary/description
+    // details to the new version
+    await this.api.updateAddonVersionDetails({
+      packageId: this.options.packageId,
+      version: newestVersion,
+      details: {
+        translations: {
+          en: {
+            short_description:
+              previousVersionDetails.translations.en!.short_description,
+          },
+        },
+      },
+    });
+
+    this.setStatus(
+      'Submitting new version for review, this may take a while... (~2 minutes)',
+    );
+
+    // For some reasons (again), this request takes about 2 min
+    // to be processed by Opera's API
+    const res = await this.api.submitVersion({
       packageId: this.options.packageId,
       versionNumber: newestVersion,
     });
+
+    if ('detail' in res) {
+      throw new Error(res.detail);
+    }
   }
 
   async ensureZipsExist(): Promise<void> {

--- a/src/opera/opera-addons-store.ts
+++ b/src/opera/opera-addons-store.ts
@@ -2,7 +2,6 @@ import { z } from 'zod/v4';
 import type { Store } from '../utils/store';
 import { ensureZipExists } from '../utils/fs';
 import { OperaAddonsApi } from './opera-api';
-import { NotImplemented } from '../utils/errors';
 
 export const OperaAddonsStoreOptions = z.object({
   zip: z.string().min(1),
@@ -71,8 +70,27 @@ export class OperaAddonsStore implements Store {
       return;
     }
 
-    // TODO: Submit changes
-    throw NotImplemented('auto submission');
+    this.setStatus('Getting new addon version');
+
+    const updatedAddon = await this.api.getAddonDetails({
+      packageId: this.options.packageId,
+    });
+
+    if ('detail' in updatedAddon) {
+      throw new Error(updatedAddon.detail);
+    }
+
+    const newestVersion = updatedAddon.versions[0]?.version;
+    if (!newestVersion) {
+      throw new Error(
+        'Something went wrong while retrieving the newly uploaded version number!',
+      );
+    }
+
+    await this.api.submitVersion({
+      packageId: this.options.packageId,
+      versionNumber: newestVersion,
+    });
   }
 
   async ensureZipsExist(): Promise<void> {

--- a/src/opera/opera-addons-store.ts
+++ b/src/opera/opera-addons-store.ts
@@ -27,11 +27,15 @@ export class OperaAddonsStore implements Store {
   async submit(dryRun?: boolean): Promise<void> {
     this.setStatus('Getting addon details');
 
-    const addon = await this.api.details({
-      packageId: this.options.packageId,
+    const credentials = {
       sessionId: this.options.sessionId,
       ingressCookie: this.options.ingressCookieApi,
       csrftoken: this.options.csrftoken,
+    };
+
+    const addon = await this.api.details({
+      packageId: this.options.packageId,
+      ...credentials,
     });
 
     if (dryRun) {
@@ -39,9 +43,32 @@ export class OperaAddonsStore implements Store {
       return;
     }
 
-    this.setStatus('Submitting new version');
+    this.setStatus('Getting last addon version');
 
-    // TODO
+    const latestVersion = addon.versions[0]?.version;
+    if (!latestVersion) {
+      throw new Error(
+        'You need at least one previous version to be uploaded before uploading a new one!',
+      );
+    }
+
+    this.setStatus('Uploading new version from zip');
+
+    const creationData = await this.api.uploadCreate({
+      packageId: this.options.packageId,
+      file: this.options.zip,
+      ...credentials,
+    });
+
+    this.setStatus('Waiting for validation results');
+    await this.api.uploadValidate({
+      packageId: this.options.packageId,
+      lastVersion: latestVersion,
+      ...creationData,
+      ...credentials,
+    });
+
+    // TODO: Submit changes
   }
 
   async ensureZipsExist(): Promise<void> {

--- a/src/opera/opera-addons-store.ts
+++ b/src/opera/opera-addons-store.ts
@@ -2,6 +2,8 @@ import { z } from 'zod/v4';
 import type { Store } from '../utils/store';
 import { ensureZipExists } from '../utils/fs';
 import { OperaAddonsApi } from './opera-api';
+import type { OperaAddonApiError } from './opera-types';
+import consola from 'consola';
 
 export const OperaAddonsStoreOptions = z.object({
   zip: z.string().min(1),
@@ -21,22 +23,27 @@ export class OperaAddonsStore implements Store {
     readonly options: OperaAddonsStoreOptions,
     readonly setStatus: (text: string) => void,
   ) {
-    this.api = new OperaAddonsApi(options);
-  }
-
-  async submit(dryRun?: boolean): Promise<void> {
-    this.setStatus('Getting addon details');
-
     const credentials = {
       sessionId: this.options.sessionId,
       ingressCookie: this.options.ingressCookieApi,
       csrftoken: this.options.csrftoken,
     };
 
-    const addon = await this.api.details({
+    this.api = new OperaAddonsApi(credentials);
+  }
+
+  async submit(dryRun?: boolean): Promise<void> {
+    this.setStatus('Getting addon details');
+
+    const addon = await this.api.getAddonDetails({
       packageId: this.options.packageId,
-      ...credentials,
     });
+
+    if ('detail' in addon) {
+      throw new Error(addon.detail);
+    }
+
+    consola.info(`Found ${addon.name} at ${addon.details_url}`);
 
     if (dryRun) {
       this.setStatus('DRY RUN: Skipped upload and publishing');
@@ -54,18 +61,16 @@ export class OperaAddonsStore implements Store {
 
     this.setStatus('Uploading new version from zip');
 
-    const creationData = await this.api.uploadCreate({
+    const creationData = await this.api.uploadFile({
       packageId: this.options.packageId,
       file: this.options.zip,
-      ...credentials,
     });
 
     this.setStatus('Waiting for validation results');
-    await this.api.uploadValidate({
+    await this.api.validateFileUpload({
       packageId: this.options.packageId,
       lastVersion: latestVersion,
       ...creationData,
-      ...credentials,
     });
 
     // TODO: Submit changes

--- a/src/opera/opera-addons-store.ts
+++ b/src/opera/opera-addons-store.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod/v4';
+import type { Store } from '../utils/store';
+import { ensureZipExists } from '../utils/fs';
+import { OperaAddonsApi } from './opera-api';
+
+export const OperaAddonsStoreOptions = z.object({
+  zip: z.string().min(1),
+  packageId: z.number().min(1),
+
+  sessionId: z.string().min(1).trim(),
+  ingressCookieApi: z.string().min(1).trim(),
+  csrftoken: z.string().min(1),
+});
+
+export type OperaAddonsStoreOptions = z.infer<typeof OperaAddonsStoreOptions>;
+
+export class OperaAddonsStore implements Store {
+  private api: OperaAddonsApi;
+
+  constructor(
+    readonly options: OperaAddonsStoreOptions,
+    readonly setStatus: (text: string) => void,
+  ) {
+    this.api = new OperaAddonsApi(options);
+  }
+
+  async submit(dryRun?: boolean): Promise<void> {
+    this.setStatus('Getting addon details');
+
+    const addon = await this.api.details({
+      packageId: this.options.packageId,
+      sessionId: this.options.sessionId,
+      ingressCookie: this.options.ingressCookieApi,
+      csrftoken: this.options.csrftoken,
+    });
+
+    if (dryRun) {
+      this.setStatus('DRY RUN: Skipped upload and publishing');
+      return;
+    }
+
+    this.setStatus('Submitting new version');
+
+    // TODO
+  }
+
+  async ensureZipsExist(): Promise<void> {
+    await ensureZipExists(this.options.zip);
+  }
+}

--- a/src/opera/opera-addons-store.ts
+++ b/src/opera/opera-addons-store.ts
@@ -2,7 +2,6 @@ import { z } from 'zod/v4';
 import type { Store } from '../utils/store';
 import { ensureZipExists } from '../utils/fs';
 import { OperaAddonsApi } from './opera-api';
-import { sleep } from '../utils/sleep';
 
 export const OperaAddonsStoreOptions = z.object({
   zip: z.string().min(1),
@@ -48,7 +47,7 @@ export class OperaAddonsStore implements Store {
 
     // For some reasons, when pushing a new version, Opera's API copies
     // almost all the details from the previous version, except for the
-    // "short summary" field. So we need to copy that part ouserselves by
+    // "short summary" field. So we need to copy that part ourselves by
     // reusing the previous version's details
     const previousVersionDetails = await this.api.getAddonVersionDetails({
       packageId: this.options.packageId,
@@ -62,7 +61,7 @@ export class OperaAddonsStore implements Store {
     if (!previousVersionDetails.translations.en?.short_description) {
       throw new Error(
         'The previous version is missing the English short description, ' +
-          'which is required to be copied to the new version.' +
+          'which is required to be copied to the new version. ' +
           'Please add it in Opera Developer Dashboard and try again.',
       );
     }
@@ -83,44 +82,23 @@ export class OperaAddonsStore implements Store {
       `File uploaded (fileId: ${creationData.fileId}), waiting for validation results...`,
     );
 
-    // Their might be some delay between the upload file request finishing and
-    // the file being actually available for validation, so we need to wait a bit
-    // before sending the validation request
-    await sleep(5_000);
-
-    await this.api.validateFileUpload({
+    const validationResult = await this.api.validateFileUpload({
       packageId: this.options.packageId,
       lastVersion: previousVersion,
       ...creationData,
     });
 
-    if (this.options.skipSubmitReview) {
-      this.setStatus('Skipping submission (skipSubmitReview=true)');
-      return;
+    if ('detail' in validationResult) {
+      throw new Error(validationResult.detail);
     }
 
-    this.setStatus('Getting new addon version');
-
-    const updatedAddon = await this.api.getAddonDetails({
-      packageId: this.options.packageId,
-    });
-
-    if ('detail' in updatedAddon) {
-      throw new Error(updatedAddon.detail);
-    }
-
-    const newestVersion = updatedAddon.versions[0]?.version;
-    if (!newestVersion) {
-      throw new Error(
-        'Something went wrong while retrieving the newly uploaded version number!',
-      );
-    }
+    this.setStatus('Updating new addon version details');
 
     // As said above, we need to copy the previous version short summary/description
     // details to the new version
-    await this.api.updateAddonVersionDetails({
+    const updatedDetails = await this.api.updateAddonVersionDetails({
       packageId: this.options.packageId,
-      version: newestVersion,
+      version: validationResult.version,
       details: {
         translations: {
           en: {
@@ -131,6 +109,15 @@ export class OperaAddonsStore implements Store {
       },
     });
 
+    if ('detail' in updatedDetails) {
+      throw new Error(updatedDetails.detail);
+    }
+
+    if (this.options.skipSubmitReview) {
+      this.setStatus('Skipping submission (skipSubmitReview=true)');
+      return;
+    }
+
     this.setStatus(
       'Submitting new version for review, this may take a while... (~2 minutes)',
     );
@@ -139,7 +126,7 @@ export class OperaAddonsStore implements Store {
     // to be processed by Opera's API
     const res = await this.api.submitVersion({
       packageId: this.options.packageId,
-      versionNumber: newestVersion,
+      versionNumber: validationResult.version,
     });
 
     if ('detail' in res) {

--- a/src/opera/opera-addons-store.ts
+++ b/src/opera/opera-addons-store.ts
@@ -2,16 +2,11 @@ import { z } from 'zod/v4';
 import type { Store } from '../utils/store';
 import { ensureZipExists } from '../utils/fs';
 import { OperaAddonsApi } from './opera-api';
-import type { OperaAddonApiError } from './opera-types';
-import consola from 'consola';
 
 export const OperaAddonsStoreOptions = z.object({
   zip: z.string().min(1),
   packageId: z.number().min(1),
-
   sessionId: z.string().min(1).trim(),
-  ingressCookieApi: z.string().min(1).trim(),
-  csrftoken: z.string().min(1),
 });
 
 export type OperaAddonsStoreOptions = z.infer<typeof OperaAddonsStoreOptions>;
@@ -23,13 +18,9 @@ export class OperaAddonsStore implements Store {
     readonly options: OperaAddonsStoreOptions,
     readonly setStatus: (text: string) => void,
   ) {
-    const credentials = {
+    this.api = new OperaAddonsApi({
       sessionId: this.options.sessionId,
-      ingressCookie: this.options.ingressCookieApi,
-      csrftoken: this.options.csrftoken,
-    };
-
-    this.api = new OperaAddonsApi(credentials);
+    });
   }
 
   async submit(dryRun?: boolean): Promise<void> {
@@ -43,7 +34,7 @@ export class OperaAddonsStore implements Store {
       throw new Error(addon.detail);
     }
 
-    consola.info(`Found ${addon.name} at ${addon.details_url}`);
+    this.setStatus(`Found ${addon.name} at ${addon.details_url}`);
 
     if (dryRun) {
       this.setStatus('DRY RUN: Skipped upload and publishing');

--- a/src/opera/opera-api.ts
+++ b/src/opera/opera-api.ts
@@ -34,8 +34,10 @@ export class OperaAddonsApi {
   private addonDetailsEndpoint = (packageId: number) =>
     `${this.operaApiUrl}/developer/packages/${packageId}/` as const;
 
+  // Trailing slash is required - Opera's backend (Django) has APPEND_SLASH=True, so a request
+  // without it gets 301-redirected, and fetch will follow the redirect as a GET, causing a 405.
   private submitVersionEndpoint = (packageId: number, version: string) =>
-    `${this.operaApiUrl}/developer/package-versions/${packageId}-${version}/submit_for_moderation` as const;
+    `${this.operaApiUrl}/developer/package-versions/${packageId}-${version}/submit_for_moderation/` as const;
 
   /**
    * Get the detailed information about an Opera Addon
@@ -96,7 +98,7 @@ export class OperaAddonsApi {
         headers: {
           ...encoder.headers,
           'x-csrftoken': this.csrfToken,
-          Referer: `https://addons.opera.com/developer/package/${params.packageId}/?tab=versions`,
+          Referer: `https://addons.opera.com/developer/package/${params.packageId}/`,
           cookie: `INGRESSCOOKIE_API; sessionid=${this.sessionId}; csrftoken=${this.csrfToken};`,
         },
         body: Readable.from(encoder),
@@ -130,7 +132,7 @@ export class OperaAddonsApi {
       method: 'POST',
       headers: {
         'x-csrftoken': this.csrfToken,
-        Referer: `https://addons.opera.com/developer/package/${params.packageId}/?tab=versions`,
+        Referer: `https://addons.opera.com/developer/package/${params.packageId}/`,
         accept: 'application/json; version=1.0',
         cookie: `INGRESSCOOKIE_API; sessionid=${this.sessionId}; csrftoken=${this.csrfToken};`,
       },
@@ -162,7 +164,7 @@ export class OperaAddonsApi {
         Referer: `https://addons.opera.com/developer/package/${params.packageId}/version/${params.versionNumber}?language=en`,
         cookie: `INGRESSCOOKIE_API; sessionid=${this.sessionId}; csrftoken=${this.csrfToken};`,
       },
-      body: {},
+      body: undefined, // No body required
     });
   }
 

--- a/src/opera/opera-api.ts
+++ b/src/opera/opera-api.ts
@@ -5,7 +5,12 @@ import { Readable } from 'node:stream';
 import fs from 'node:fs';
 import path from 'node:path';
 import { Blob } from 'node:buffer';
-import type { OperaAddonApiError, OperaAddonDetails } from './opera-types';
+import type {
+  OperaAddonApiError,
+  OperaAddonDetails,
+  OperaAddonVersionDetails,
+} from './opera-types';
+import type { DeepPartial } from '../utils/types';
 
 // API guessed from : https://addons-static.operacdn.com/static/CACHE/js/catalog.6c1172c19572.js
 // And by looking at the HTTP requests while using the website
@@ -39,6 +44,9 @@ export class OperaAddonsApi {
   private submitVersionEndpoint = (packageId: number, version: string) =>
     `${this.operaApiUrl}/developer/package-versions/${packageId}-${version}/submit_for_moderation/` as const;
 
+  private addonVersionDetailsEndpoint = (packageId: number, version: string) =>
+    `${this.operaApiUrl}/developer/package-versions/${packageId}-${version}/` as const;
+
   /**
    * Get the detailed information about an Opera Addon
    */
@@ -53,6 +61,46 @@ export class OperaAddonsApi {
         accept: 'application/json; version=1.0',
         cookie: `INGRESSCOOKIE_API; sessionid=${this.sessionId};`,
       },
+    });
+  }
+
+  public async getAddonVersionDetails(params: {
+    packageId: number;
+    version: string;
+  }): Promise<OperaAddonVersionDetails | OperaAddonApiError> {
+    const endpoint = this.addonVersionDetailsEndpoint(
+      params.packageId,
+      params.version,
+    );
+
+    return await fetch(endpoint, {
+      method: 'GET',
+      headers: {
+        accept: 'application/json; version=1.0',
+        cookie: `INGRESSCOOKIE_API; sessionid=${this.sessionId};`,
+      },
+    });
+  }
+
+  public async updateAddonVersionDetails(params: {
+    packageId: number;
+    version: string;
+    details: DeepPartial<OperaAddonVersionDetails>;
+  }): Promise<OperaAddonVersionDetails | OperaAddonApiError> {
+    const endpoint = this.addonVersionDetailsEndpoint(
+      params.packageId,
+      params.version,
+    );
+
+    return await fetch(endpoint, {
+      method: 'PATCH',
+      headers: {
+        accept: 'application/json; version=1.0',
+        'x-csrftoken': this.csrfToken,
+        cookie: `INGRESSCOOKIE_API; sessionid=${this.sessionId}; csrftoken=${this.csrfToken};`,
+        Referer: `https://addons.opera.com/developer/package/${params.packageId}/version/${params.version}`,
+      },
+      body: JSON.stringify(params.details),
     });
   }
 
@@ -150,7 +198,7 @@ export class OperaAddonsApi {
   public async submitVersion(params: {
     packageId: number;
     versionNumber: string;
-  }) {
+  }): Promise<OperaAddonVersionDetails | OperaAddonApiError> {
     const endpoint = this.submitVersionEndpoint(
       params.packageId,
       params.versionNumber,

--- a/src/opera/opera-api.ts
+++ b/src/opera/opera-api.ts
@@ -8,6 +8,7 @@ import { Blob } from 'node:buffer';
 import type {
   OperaAddonApiError,
   OperaAddonDetails,
+  OperaAddonFileValidationResponse,
   OperaAddonVersionDetails,
 } from './opera-types';
 import type { DeepPartial } from '../utils/types';
@@ -22,11 +23,10 @@ export interface OperaAddonsApiOptions {
 export class OperaAddonsApi {
   private readonly operaApiUrl = 'https://addons.opera.com/api';
   private readonly csrfToken: string;
+  private readonly sessionId: string;
 
-  constructor(
-    options: OperaAddonsApiOptions,
-    private readonly sessionId: string = options.sessionId,
-  ) {
+  constructor(options: OperaAddonsApiOptions) {
+    this.sessionId = options.sessionId;
     this.csrfToken = this.generateCSRFToken();
   }
 
@@ -100,7 +100,7 @@ export class OperaAddonsApi {
         cookie: `INGRESSCOOKIE_API; sessionid=${this.sessionId}; csrftoken=${this.csrfToken};`,
         Referer: `https://addons.opera.com/developer/package/${params.packageId}/version/${params.version}`,
       },
-      body: JSON.stringify(params.details),
+      body: params.details,
     });
   }
 
@@ -173,7 +173,7 @@ export class OperaAddonsApi {
     fileId: `${number}-${string}`;
     fileName: string;
     lastVersion: string;
-  }): Promise<unknown> {
+  }): Promise<OperaAddonFileValidationResponse | OperaAddonApiError> {
     const endpoint = this.uploadValidateEndpoint(params.packageId);
 
     return fetch(endpoint, {
@@ -189,6 +189,15 @@ export class OperaAddonsApi {
         file_name: params.fileName,
         metadata_from: params.lastVersion,
       },
+      // There might be some delay between the upload file request finishing and
+      // the file being actually available for validation, so the request might
+      // fail. To work around this, we retry a few times with some delay.
+      retry: 10,
+      retryDelay: 5_000,
+      retryStatusCodes: [400, 500, 502, 503, 504],
+      // empty method to avoid spamming the console with HTML error responses
+      // from the server while retrying
+      onResponseError: async () => {},
     });
   }
 
@@ -216,7 +225,7 @@ export class OperaAddonsApi {
     });
   }
 
-  // Opera use the standard Django CSRF token, which is a 32 character long random string.
+  // Opera uses the standard Django CSRF token, which is a 32-character-long random string.
   // In the context of this API, we can just use a fixed string since it doesn't need to be valid.
   // See : https://docs.djangoproject.com/en/4.2/ref/csrf/#ajax for more details about how Django CSRF tokens work.
   private generateCSRFToken = () => '12345678901234567890123456789012';

--- a/src/opera/opera-api.ts
+++ b/src/opera/opera-api.ts
@@ -11,20 +11,19 @@ import type { OperaAddonApiError, OperaAddonDetails } from './opera-types';
 // And by looking at the HTTP requests while using the website
 
 export interface OperaAddonsApiOptions {
-  apiUrl?: string;
-  ingressCookie: string;
   sessionId: string;
-  csrftoken: string;
 }
 
 export class OperaAddonsApi {
+  private readonly operaApiUrl = 'https://addons.opera.com/api';
+  private readonly csrfToken: string;
+
   constructor(
-    readonly options: OperaAddonsApiOptions,
-    private readonly operaApiUrl: string = options.apiUrl ??
-      'https://addons.opera.com/api',
+    options: OperaAddonsApiOptions,
     private readonly sessionId: string = options.sessionId,
-    private readonly ingressCookie: string = options.ingressCookie,
-  ) {}
+  ) {
+    this.csrfToken = this.generateCSRFToken();
+  }
 
   private uploadFileEndpoint = () =>
     `${this.operaApiUrl}/file-upload/` as const;
@@ -55,7 +54,7 @@ export class OperaAddonsApi {
       method: 'GET',
       headers: {
         accept: 'application/json; version=1.0',
-        cookie: `INGRESSCOOKIE_API=${this.ingressCookie}; sessionid=${this.sessionId};`,
+        cookie: `INGRESSCOOKIE_API; sessionid=${this.sessionId};`,
       },
     });
   }
@@ -101,9 +100,9 @@ export class OperaAddonsApi {
         method: 'POST',
         headers: {
           ...encoder.headers,
-          'x-csrftoken': this.csrftoken,
+          'x-csrftoken': this.csrfToken,
           Referer: `https://addons.opera.com/developer/package/${params.packageId}/?tab=versions`,
-          cookie: `INGRESSCOOKIE_API=${this.ingressCookie}; sessionid=${this.sessionId}; csrftoken=${this.csrftoken};`,
+          cookie: `INGRESSCOOKIE_API; sessionid=${this.sessionId}; csrftoken=${this.csrfToken};`,
         },
         body: Readable.from(encoder),
       });
@@ -135,10 +134,10 @@ export class OperaAddonsApi {
     return fetch(endpoint, {
       method: 'POST',
       headers: {
-        'x-csrftoken': this.csrftoken,
+        'x-csrftoken': this.csrfToken,
         Referer: `https://addons.opera.com/developer/package/${params.packageId}/?tab=versions`,
         accept: 'application/json; version=1.0',
-        cookie: `INGRESSCOOKIE_API=${this.ingressCookie}; sessionid=${this.sessionId}; csrftoken=${this.csrftoken};`,
+        cookie: `INGRESSCOOKIE_API; sessionid=${this.sessionId}; csrftoken=${this.csrfToken};`,
       },
       body: {
         file_id: params.fileId,
@@ -147,6 +146,8 @@ export class OperaAddonsApi {
       },
     });
   }
+
+  private generateCSRFToken = () => '12345678901234567890123456789012'; // should be 32 chars long
 
   private generateFileIdentifier = (
     size: number,

--- a/src/opera/opera-api.ts
+++ b/src/opera/opera-api.ts
@@ -5,158 +5,57 @@ import { Readable } from 'node:stream';
 import fs from 'node:fs';
 import path from 'node:path';
 import { Blob } from 'node:buffer';
+import type { OperaAddonApiError, OperaAddonDetails } from './opera-types';
 
 // API guessed from : https://addons-static.operacdn.com/static/CACHE/js/catalog.6c1172c19572.js
 // And by looking at the HTTP requests while using the website
 
-export interface OperaAddonsApiOptions {}
-
-export interface OperaAddonDetails {
-  id: number;
-  slug: string;
-  name: string;
-  type: 'extensions' | (string & {});
-  versions: Array<{
-    version: string;
-    submitted_for_moderation: boolean;
-    type: string;
-    created: string;
-    warnings: unknown[];
-    retirejs_warnings: unknown[];
-  }>;
-  published_versions: Array<{
-    name: 'Opera' | (string & {});
-    version: unknown | null;
-  }>;
-  developer: string; // uuid v4
-  is_editable: boolean;
-  app_id: string;
-  category: {
-    slug: string;
-    name: string;
-  };
-  warnings: string[];
-  unlisted: boolean;
-  details_url: `https://addons.opera.com/en/${string}/details/${string}/`;
-  is_published: boolean;
-  available_auto_moderation: boolean;
-  dev_promotional_image: unknown | null;
-  is_extension: boolean;
-  retirejs_warnings: unknown[];
-}
-
-export interface OperaAddonVersionDetails {
-  version: string;
-  submitted_for_moderation: boolean;
-  support: string;
-  source_url: string;
-  service_url: string | null;
-  source_for_moderators_url: string;
-  build_instructions: string;
-  features: Array<{
-    name: string;
-  }>;
-  file_size: number;
-  icon: {
-    id: number;
-    width: 64;
-    height: 64;
-    url: string;
-  };
-  screenshots: Record<number, { id: number; url: string }> | null;
-  video: Record<number, { id: number; url: string }> | null;
-  license: { url: string; full_text: null } | { url: null; full_text: string };
-  privacy_policy:
-    | { url: string; full_text: null }
-    | { url: null; full_text: string };
-  translations: Record<
-    string,
-    {
-      language: {
-        code: string;
-        name: string;
-      };
-      short_description: string;
-      long_description: string;
-      changelog: string | null;
-    }
-  >;
-  type: string;
-  created: string;
-  warnings: string[];
-  download_url: `https://addons.opera.com/en/package/download/revision/${string /* slug */}/${string /* version */}/?zip=1&dev-panel=1`;
-  retirejs_warnings: unknown[];
-}
-
-export interface OperaCookiesParams {
+export interface OperaAddonsApiOptions {
+  apiUrl?: string;
   ingressCookie: string;
   sessionId: string;
   csrftoken: string;
 }
 
 export class OperaAddonsApi {
-  constructor(readonly options: OperaAddonsApiOptions) {}
+  constructor(
+    readonly options: OperaAddonsApiOptions,
+    private readonly operaApiUrl: string = options.apiUrl ??
+      'https://addons.opera.com/api',
+    private readonly sessionId: string = options.sessionId,
+    private readonly ingressCookie: string = options.ingressCookie,
+  ) {}
 
-  private addonsUploadCreateEndpoint() {
-    return new URL('https://addons.opera.com/api/file-upload/');
-  }
+  private uploadFileEndpoint = () =>
+    `${this.operaApiUrl}/file-upload/` as const;
 
-  private addonsUploadValidateEndpoint(packageId: number) {
-    return new URL(
-      `https://addons.opera.com/api/developer/package-versions/?package_id=${packageId}`,
-    );
-  }
+  private uploadValidateEndpoint = (packageId: number) =>
+    `${this.operaApiUrl}/developer/package-versions/?package_id=${packageId}` as const;
 
-  private addonsDetailsEndpoint(packageId: number) {
-    return new URL(
-      `https://addons.opera.com/api/developer/packages/${packageId}/`,
-    );
-  }
+  private addonDetailsEndpoint = (packageId: number) =>
+    `${this.operaApiUrl}/developer/packages/${packageId}/` as const;
 
-  private addonsVersionDetailsEndpoint(packageId: number, version: string) {
-    return new URL(
-      `https://addons.opera.com/api/developer/package-versions/${packageId}-${version}/`,
-    );
-  }
+  // unused
+  private addonVersionDetailsEndpoint = (packageId: number, version: string) =>
+    `${this.operaApiUrl}/developer/package-versions/${packageId}-${version}/` as const;
+
+  // unused
+  private addonDownloadStats = (packageId: number) =>
+    `${this.operaApiUrl}/developer/download-stats/${packageId}/` as const;
 
   /**
    * Get the detailed information about an Opera Addon
    */
-  async details(
-    params: OperaCookiesParams & {
-      packageId: number;
-    },
-  ): Promise<OperaAddonDetails> {
-    const endpoint = this.addonsDetailsEndpoint(params.packageId);
+  public async getAddonDetails(params: {
+    packageId: number;
+  }): Promise<OperaAddonDetails | OperaAddonApiError> {
+    const endpoint = this.addonDetailsEndpoint(params.packageId);
 
-    return await fetch(endpoint.href, {
+    return await fetch(endpoint, {
       method: 'GET',
       headers: {
         accept: 'application/json; version=1.0',
-        ...this.getCookieHeaders(params),
-      },
-    });
-  }
-
-  /**
-   * Get the detailed information about a package version for an Opera Addon
-   */
-  async addonVersionDetails(
-    params: OperaCookiesParams & {
-      packageId: number;
-      version: string;
-    },
-  ): Promise<OperaAddonVersionDetails> {
-    const endpoint = this.addonsVersionDetailsEndpoint(
-      params.packageId,
-      params.version,
-    );
-
-    return await fetch(endpoint.href, {
-      method: 'GET',
-      headers: {
-        accept: 'application/json; version=1.0',
-        ...this.getCookieHeaders(params),
+        cookie: `INGRESSCOOKIE_API=${this.ingressCookie}; sessionid=${this.sessionId};`,
       },
     });
   }
@@ -164,19 +63,17 @@ export class OperaAddonsApi {
   /**
    * Upload a new package version for an Opera Addon
    */
-  async uploadCreate(
-    params: OperaCookiesParams & {
-      packageId: number;
-      file: string;
-    },
-  ) {
-    const endpoint = this.addonsUploadCreateEndpoint();
+  public async uploadFile(params: { packageId: number; file: string }) {
+    const endpoint = this.uploadFileEndpoint();
     const fileInfo = await this.fileInfo(params.file);
 
     const chunkSize = 1024 * 1024;
     const totalChunks = Math.ceil(fileInfo.size / chunkSize);
 
-    const identifier = this.generateIdentifier(fileInfo.size, fileInfo.name);
+    const identifier = this.generateFileIdentifier(
+      fileInfo.size,
+      fileInfo.name,
+    );
 
     const stream = fs.createReadStream(params.file, {
       highWaterMark: chunkSize,
@@ -200,12 +97,13 @@ export class OperaAddonsApi {
 
       const encoder = new FormDataEncoder(form);
 
-      const res = await fetch.raw(endpoint.href, {
+      const res = await fetch.raw(endpoint, {
         method: 'POST',
         headers: {
           ...encoder.headers,
-          ...this.getCookieHeaders(params),
+          'x-csrftoken': this.csrftoken,
           Referer: `https://addons.opera.com/developer/package/${params.packageId}/?tab=versions`,
+          cookie: `INGRESSCOOKIE_API=${this.ingressCookie}; sessionid=${this.sessionId}; csrftoken=${this.csrftoken};`,
         },
         body: Readable.from(encoder),
       });
@@ -220,25 +118,27 @@ export class OperaAddonsApi {
     return {
       fileId: identifier,
       fileName: fileInfo.name,
-    };
+    } as const;
   }
 
-  async uploadValidate(
-    params: OperaCookiesParams & {
-      packageId: number;
-      fileId: `${number}-${string}`;
-      fileName: string;
-      lastVersion: string;
-    },
-  ) {
-    const endpoint = this.addonsUploadValidateEndpoint(params.packageId);
+  /**
+   * Bind an uploaded file to an addon package
+   */
+  public async validateFileUpload(params: {
+    packageId: number;
+    fileId: `${number}-${string}`;
+    fileName: string;
+    lastVersion: string;
+  }): Promise<unknown> {
+    const endpoint = this.uploadValidateEndpoint(params.packageId);
 
-    return fetch(endpoint.href, {
+    return fetch(endpoint, {
       method: 'POST',
       headers: {
-        ...this.getCookieHeaders(params),
-        accept: 'application/json; version=1.0',
+        'x-csrftoken': this.csrftoken,
         Referer: `https://addons.opera.com/developer/package/${params.packageId}/?tab=versions`,
+        accept: 'application/json; version=1.0',
+        cookie: `INGRESSCOOKIE_API=${this.ingressCookie}; sessionid=${this.sessionId}; csrftoken=${this.csrftoken};`,
       },
       body: {
         file_id: params.fileId,
@@ -248,12 +148,10 @@ export class OperaAddonsApi {
     });
   }
 
-  private generateIdentifier(
+  private generateFileIdentifier = (
     size: number,
     name: string,
-  ): `${number}-${string}` {
-    return `${size}-${name.replace(/[^0-9a-zA-Z_-]/g, '')}`;
-  }
+  ): `${number}-${string}` => `${size}-${name.replace(/[^0-9a-zA-Z_-]/g, '')}`;
 
   private async fileInfo(filepath: string) {
     const stat = await fs.promises.stat(filepath);
@@ -261,13 +159,6 @@ export class OperaAddonsApi {
       path: filepath,
       name: path.basename(filepath),
       size: stat.size,
-    };
-  }
-
-  private getCookieHeaders(params: OperaCookiesParams) {
-    return {
-      cookie: `INGRESSCOOKIE_API=${params.ingressCookie}; sessionid=${params.sessionId}; csrftoken=${params.csrftoken};`,
-      'x-csrftoken': params.csrftoken,
     };
   }
 }

--- a/src/opera/opera-api.ts
+++ b/src/opera/opera-api.ts
@@ -34,13 +34,8 @@ export class OperaAddonsApi {
   private addonDetailsEndpoint = (packageId: number) =>
     `${this.operaApiUrl}/developer/packages/${packageId}/` as const;
 
-  // unused
-  private addonVersionDetailsEndpoint = (packageId: number, version: string) =>
-    `${this.operaApiUrl}/developer/package-versions/${packageId}-${version}/` as const;
-
-  // unused
-  private addonDownloadStats = (packageId: number) =>
-    `${this.operaApiUrl}/developer/download-stats/${packageId}/` as const;
+  private submitVersionEndpoint = (packageId: number, version: string) =>
+    `${this.operaApiUrl}/developer/package-versions/${packageId}-${version}/submit_for_moderation` as const;
 
   /**
    * Get the detailed information about an Opera Addon
@@ -147,7 +142,34 @@ export class OperaAddonsApi {
     });
   }
 
-  private generateCSRFToken = () => '12345678901234567890123456789012'; // should be 32 chars long
+  /**
+   * Submit given version for moderation review
+   */
+  public async submitVersion(params: {
+    packageId: number;
+    versionNumber: string;
+  }) {
+    const endpoint = this.submitVersionEndpoint(
+      params.packageId,
+      params.versionNumber,
+    );
+
+    return fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json; version=1.0',
+        'x-csrftoken': this.csrfToken,
+        Referer: `https://addons.opera.com/developer/package/${params.packageId}/version/${params.versionNumber}?language=en`,
+        cookie: `INGRESSCOOKIE_API; sessionid=${this.sessionId}; csrftoken=${this.csrfToken};`,
+      },
+      body: {},
+    });
+  }
+
+  // Opera use the standard Django CSRF token, which is a 32 character long random string.
+  // In the context of this API, we can just use a fixed string since it doesn't need to be valid.
+  // See : https://docs.djangoproject.com/en/4.2/ref/csrf/#ajax for more details about how Django CSRF tokens work.
+  private generateCSRFToken = () => '12345678901234567890123456789012';
 
   private generateFileIdentifier = (
     size: number,

--- a/src/opera/opera-api.ts
+++ b/src/opera/opera-api.ts
@@ -1,5 +1,10 @@
 import { fetch } from '../utils/fetch';
-import { fileFromPath } from 'formdata-node/file-from-path';
+import { FormData } from 'formdata-node';
+import { FormDataEncoder } from 'form-data-encoder';
+import { Readable } from 'node:stream';
+import fs from 'node:fs';
+import path from 'node:path';
+import { Blob } from 'node:buffer';
 
 // API guessed from : https://addons-static.operacdn.com/static/CACHE/js/catalog.6c1172c19572.js
 // And by looking at the HTTP requests while using the website
@@ -96,6 +101,12 @@ export class OperaAddonsApi {
     return new URL('https://addons.opera.com/api/file-upload/');
   }
 
+  private addonsUploadValidateEndpoint(packageId: number) {
+    return new URL(
+      `https://addons.opera.com/api/developer/package-versions/?package_id=${packageId}`,
+    );
+  }
+
   private addonsDetailsEndpoint(packageId: number) {
     return new URL(
       `https://addons.opera.com/api/developer/packages/${packageId}/`,
@@ -148,6 +159,109 @@ export class OperaAddonsApi {
         ...this.getCookieHeaders(params),
       },
     });
+  }
+
+  /**
+   * Upload a new package version for an Opera Addon
+   */
+  async uploadCreate(
+    params: OperaCookiesParams & {
+      packageId: number;
+      file: string;
+    },
+  ) {
+    const endpoint = this.addonsUploadCreateEndpoint();
+    const fileInfo = await this.fileInfo(params.file);
+
+    const chunkSize = 1024 * 1024;
+    const totalChunks = Math.ceil(fileInfo.size / chunkSize);
+
+    const identifier = this.generateIdentifier(fileInfo.size, fileInfo.name);
+
+    const stream = fs.createReadStream(params.file, {
+      highWaterMark: chunkSize,
+    });
+
+    let chunkNumber = 1;
+
+    for await (const chunk of stream) {
+      const form = new FormData();
+
+      form.append('file', new Blob([chunk]), fileInfo.name);
+
+      form.append('flowChunkNumber', String(chunkNumber));
+      form.append('flowChunkSize', String(chunkSize));
+      form.append('flowCurrentChunkSize', String(chunk.length));
+      form.append('flowTotalSize', String(fileInfo.size));
+      form.append('flowIdentifier', identifier);
+      form.append('flowFilename', fileInfo.name);
+      form.append('flowRelativePath', fileInfo.name);
+      form.append('flowTotalChunks', String(totalChunks));
+
+      const encoder = new FormDataEncoder(form);
+
+      const res = await fetch.raw(endpoint.href, {
+        method: 'POST',
+        headers: {
+          ...encoder.headers,
+          ...this.getCookieHeaders(params),
+          Referer: `https://addons.opera.com/developer/package/${params.packageId}/?tab=versions`,
+        },
+        body: Readable.from(encoder),
+      });
+
+      if (res.status < 200 || res.status >= 300) {
+        throw new Error(`Chunk ${chunkNumber} upload failed (${res.status})`);
+      }
+
+      chunkNumber++;
+    }
+
+    return {
+      fileId: identifier,
+      fileName: fileInfo.name,
+    };
+  }
+
+  async uploadValidate(
+    params: OperaCookiesParams & {
+      packageId: number;
+      fileId: `${number}-${string}`;
+      fileName: string;
+      lastVersion: string;
+    },
+  ) {
+    const endpoint = this.addonsUploadValidateEndpoint(params.packageId);
+
+    return fetch(endpoint.href, {
+      method: 'POST',
+      headers: {
+        ...this.getCookieHeaders(params),
+        accept: 'application/json; version=1.0',
+        Referer: `https://addons.opera.com/developer/package/${params.packageId}/?tab=versions`,
+      },
+      body: {
+        file_id: params.fileId,
+        file_name: params.fileName,
+        metadata_from: params.lastVersion,
+      },
+    });
+  }
+
+  private generateIdentifier(
+    size: number,
+    name: string,
+  ): `${number}-${string}` {
+    return `${size}-${name.replace(/[^0-9a-zA-Z_-]/g, '')}`;
+  }
+
+  private async fileInfo(filepath: string) {
+    const stat = await fs.promises.stat(filepath);
+    return {
+      path: filepath,
+      name: path.basename(filepath),
+      size: stat.size,
+    };
   }
 
   private getCookieHeaders(params: OperaCookiesParams) {

--- a/src/opera/opera-api.ts
+++ b/src/opera/opera-api.ts
@@ -1,0 +1,159 @@
+import { fetch } from '../utils/fetch';
+import { fileFromPath } from 'formdata-node/file-from-path';
+
+// API guessed from : https://addons-static.operacdn.com/static/CACHE/js/catalog.6c1172c19572.js
+// And by looking at the HTTP requests while using the website
+
+export interface OperaAddonsApiOptions {}
+
+export interface OperaAddonDetails {
+  id: number;
+  slug: string;
+  name: string;
+  type: 'extensions' | (string & {});
+  versions: Array<{
+    version: string;
+    submitted_for_moderation: boolean;
+    type: string;
+    created: string;
+    warnings: unknown[];
+    retirejs_warnings: unknown[];
+  }>;
+  published_versions: Array<{
+    name: 'Opera' | (string & {});
+    version: unknown | null;
+  }>;
+  developer: string; // uuid v4
+  is_editable: boolean;
+  app_id: string;
+  category: {
+    slug: string;
+    name: string;
+  };
+  warnings: string[];
+  unlisted: boolean;
+  details_url: `https://addons.opera.com/en/${string}/details/${string}/`;
+  is_published: boolean;
+  available_auto_moderation: boolean;
+  dev_promotional_image: unknown | null;
+  is_extension: boolean;
+  retirejs_warnings: unknown[];
+}
+
+export interface OperaAddonVersionDetails {
+  version: string;
+  submitted_for_moderation: boolean;
+  support: string;
+  source_url: string;
+  service_url: string | null;
+  source_for_moderators_url: string;
+  build_instructions: string;
+  features: Array<{
+    name: string;
+  }>;
+  file_size: number;
+  icon: {
+    id: number;
+    width: 64;
+    height: 64;
+    url: string;
+  };
+  screenshots: Record<number, { id: number; url: string }> | null;
+  video: Record<number, { id: number; url: string }> | null;
+  license: { url: string; full_text: null } | { url: null; full_text: string };
+  privacy_policy:
+    | { url: string; full_text: null }
+    | { url: null; full_text: string };
+  translations: Record<
+    string,
+    {
+      language: {
+        code: string;
+        name: string;
+      };
+      short_description: string;
+      long_description: string;
+      changelog: string | null;
+    }
+  >;
+  type: string;
+  created: string;
+  warnings: string[];
+  download_url: `https://addons.opera.com/en/package/download/revision/${string /* slug */}/${string /* version */}/?zip=1&dev-panel=1`;
+  retirejs_warnings: unknown[];
+}
+
+export interface OperaCookiesParams {
+  ingressCookie: string;
+  sessionId: string;
+  csrftoken: string;
+}
+
+export class OperaAddonsApi {
+  constructor(readonly options: OperaAddonsApiOptions) {}
+
+  private addonsUploadCreateEndpoint() {
+    return new URL('https://addons.opera.com/api/file-upload/');
+  }
+
+  private addonsDetailsEndpoint(packageId: number) {
+    return new URL(
+      `https://addons.opera.com/api/developer/packages/${packageId}/`,
+    );
+  }
+
+  private addonsVersionDetailsEndpoint(packageId: number, version: string) {
+    return new URL(
+      `https://addons.opera.com/api/developer/package-versions/${packageId}-${version}/`,
+    );
+  }
+
+  /**
+   * Get the detailed information about an Opera Addon
+   */
+  async details(
+    params: OperaCookiesParams & {
+      packageId: number;
+    },
+  ): Promise<OperaAddonDetails> {
+    const endpoint = this.addonsDetailsEndpoint(params.packageId);
+
+    return await fetch(endpoint.href, {
+      method: 'GET',
+      headers: {
+        accept: 'application/json; version=1.0',
+        ...this.getCookieHeaders(params),
+      },
+    });
+  }
+
+  /**
+   * Get the detailed information about a package version for an Opera Addon
+   */
+  async addonVersionDetails(
+    params: OperaCookiesParams & {
+      packageId: number;
+      version: string;
+    },
+  ): Promise<OperaAddonVersionDetails> {
+    const endpoint = this.addonsVersionDetailsEndpoint(
+      params.packageId,
+      params.version,
+    );
+
+    return await fetch(endpoint.href, {
+      method: 'GET',
+      headers: {
+        accept: 'application/json; version=1.0',
+        ...this.getCookieHeaders(params),
+      },
+    });
+  }
+
+  private getCookieHeaders(params: OperaCookiesParams) {
+    return {
+      cookie: `INGRESSCOOKIE_API=${params.ingressCookie}; sessionid=${params.sessionId}; csrftoken=${params.csrftoken};`,
+      'x-csrftoken': params.csrftoken,
+    };
+  }
+}

--- a/src/opera/opera-types.ts
+++ b/src/opera/opera-types.ts
@@ -35,3 +35,48 @@ export interface OperaAddonDetails {
   is_extension: boolean;
   retirejs_warnings: unknown[];
 }
+
+export interface OperaAddonVersionDetails {
+  version: string;
+  submitted_for_moderation: boolean;
+  support: unknown | null;
+  source_url: string | null;
+  service_url: string | null;
+  source_for_moderators_url: string | null;
+  build_instructions: string | null;
+  features: unknown[];
+  file_size: number;
+  icon: {
+    id: number;
+    width: number;
+    height: number;
+    url: string;
+  } | null;
+  screenshots: Record<
+    number,
+    {
+      id: number;
+      url: string;
+    }
+  >;
+  video: string | null;
+  license: string | null;
+  privacy_policy: string | null;
+  translations: Record<
+    string,
+    {
+      language: {
+        code: string;
+        name: string;
+      };
+      short_description: string;
+      long_description: string;
+      changelog: string | null;
+    }
+  >;
+  type: 'Chromium Extension';
+  created: string;
+  warnings: unknown[];
+  download_url: string;
+  retirejs_warnings: unknown[];
+}

--- a/src/opera/opera-types.ts
+++ b/src/opera/opera-types.ts
@@ -36,6 +36,14 @@ export interface OperaAddonDetails {
   retirejs_warnings: unknown[];
 }
 
+export interface OperaAddonFileValidationResponse {
+  version: string;
+  submitted_for_moderation: boolean;
+  type: string;
+  created: string;
+  warnings: string[];
+}
+
 export interface OperaAddonVersionDetails {
   version: string;
   submitted_for_moderation: boolean;

--- a/src/opera/opera-types.ts
+++ b/src/opera/opera-types.ts
@@ -1,0 +1,37 @@
+export interface OperaAddonApiError {
+  detail: string;
+}
+
+export interface OperaAddonDetails {
+  id: number;
+  slug: string;
+  name: string;
+  type: 'extensions' | (string & {});
+  versions: Array<{
+    version: string;
+    submitted_for_moderation: boolean;
+    type: string;
+    created: string;
+    warnings: string[];
+    retirejs_warnings: unknown[];
+  }>;
+  published_versions: Array<{
+    name: 'Opera' | (string & {});
+    version: unknown | null;
+  }>;
+  developer: string; // uuid v4
+  is_editable: boolean;
+  app_id: string;
+  category: {
+    slug: string;
+    name: string;
+  };
+  warnings: string[];
+  unlisted: boolean;
+  details_url: `https://addons.opera.com/en/${string}/details/${string}/`;
+  is_published: boolean;
+  available_auto_moderation: boolean;
+  dev_promotional_image: unknown | null;
+  is_extension: boolean;
+  retirejs_warnings: unknown[];
+}

--- a/src/submit.ts
+++ b/src/submit.ts
@@ -3,6 +3,7 @@ import { ChromeWebStore } from './chrome';
 import { InlineConfig, resolveConfig, validateConfig } from './config';
 import { EdgeAddonStore } from './edge';
 import { FirefoxAddonStore } from './firefox';
+import { OperaAddonsStore } from './opera';
 import type { Store, SubmitResult } from './utils/store';
 import { consola } from 'consola';
 
@@ -68,6 +69,14 @@ export async function submit(config: InlineConfig): Promise<SubmitResults> {
       name: 'Edge Addon Store',
       getStore: setStatus =>
         new EdgeAddonStore(internalConfig.edge!, setStatus),
+    });
+  }
+  if (internalConfig.opera) {
+    stores.push({
+      id: 'opera',
+      name: 'Opera Addons',
+      getStore: setStatus =>
+        new OperaAddonsStore(internalConfig.opera!, setStatus),
     });
   }
 


### PR DESCRIPTION
# Feature Request
- #47

## Added

### Checklist

- [x] #60 
- [x] Add CLI commands for [Opera](https://addons.opera.com/developer/)
- [x] Add Init setup for Opera
- [x] Add Opera Addon extension publishing support
  - [x] Get a package details
  - [x] Upload a zip file
  - [x] Attach the zip file to the package
  - [x] Submit the zip file for review

### New options for `publish-extension`

```
publish-extension --opera-zip [operaZip] \
   --opera-package-id [packageId] \
   --opera-session-id [sessionId] \
   --opera-skip-submit-review
```

## Notes

I've decided to not use https://github.com/LinusU/upload-opera-extension as a base as it's using puppeteer (which is very _heavy_) and mostly because it's more of a "hack" than a viable solution ~~which seems to be broken?~~ (even though I've scraped the API calls myself for this PR)