### PR TITLE
fix: Fix invalid chrome zips

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,6 +1,6 @@
 name: Validate
 on:
-  pull_request_target:
+  pull_request:
   workflow_call:
   workflow_dispatch:
   push:
@@ -21,6 +21,8 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-24.04
+    # If PR is from a fork, secrets aren't available, so skip this job.
+    if: github.event.pull_request.head.repo.fork != true
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup

--- a/src/chrome/chrome-api.ts
+++ b/src/chrome/chrome-api.ts
@@ -53,7 +53,6 @@ export class CwsApi {
 
     const endpoint = this.uploadEndpoint(params.extensionId);
     const file = createReadStream(params.zipFile);
-    console.log('NEW CODE');
     const res: CwsItemResponse = await fetch(endpoint.href, {
       method: 'PUT',
       body: file,

--- a/src/chrome/chrome-api.ts
+++ b/src/chrome/chrome-api.ts
@@ -53,6 +53,7 @@ export class CwsApi {
 
     const endpoint = this.uploadEndpoint(params.extensionId);
     const file = createReadStream(params.zipFile);
+    console.log('NEW CODE');
     const res: CwsItemResponse = await fetch(endpoint.href, {
       method: 'PUT',
       body: file,

--- a/src/chrome/chrome-api.ts
+++ b/src/chrome/chrome-api.ts
@@ -1,5 +1,4 @@
-import { FormData } from 'formdata-node';
-import { fileFromPath } from 'formdata-node/file-from-path';
+import { createReadStream } from 'node:fs';
 import { fetch } from '../utils/fetch';
 
 export interface CwsApiOptions {
@@ -53,11 +52,10 @@ export class CwsApi {
     const Authorization = await this.getAuthHeader(params.token);
 
     const endpoint = this.uploadEndpoint(params.extensionId);
-    const form = new FormData();
-    form.append('image', await fileFromPath(params.zipFile));
+    const file = createReadStream(params.zipFile);
     const res: CwsItemResponse = await fetch(endpoint.href, {
       method: 'PUT',
-      body: form,
+      body: file,
       headers: {
         Authorization,
         'x-goog-api-version': '2',


### PR DESCRIPTION
Fixes this error:

```
[info] Publishing Extension
❯ Chrome Web Store
› [chrome] Checking ZIP files exist
› [chrome] Getting an access token
› [chrome] Uploading new ZIP file
Error:  Chrome Web Store upload failed:
PKG_INVALID_ZIP: Invalid package. Please make sure it is a valid zip file and the file manifest.json is at the root directory of the zip package.
  at uploadZip (dist/init-Bni1mFNi.mjs:49:14)
  at async submit (dist/init-Bni1mFNi.mjs:126:13)
  at async task (dist/init-Bni1mFNi.mjs:569:17)
  at processTicksAndRejections (native:7:39)
✖ Chrome Web Store [FAILED: Chrome Web Store upload failed:
PKG_INVALID_ZIP: Invalid package. Please make sure it is a valid zip file and the file manifest.json is at the root directory of the zip package.]
```