### PR TITLE
chore: Drop `jsonwebtoken` and implement `sign` function locally

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,6 @@
         "dotenv": "^17.2.4",
         "form-data-encoder": "^4.1.0",
         "formdata-node": "^6.0.3",
-        "jsonwebtoken": "^9.0.3",
         "listr2": "^10.1.0",
         "ofetch": "^1.5.1",
         "zod": "3.25.76 || ^4.3.6",
@@ -18,7 +17,6 @@
       "devDependencies": {
         "@aklinker1/check": "^2.2.0",
         "@types/bun": "^1.3.14",
-        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^25.2.2",
         "@typescript/native-preview": "^7.0.0-dev.20260208.1",
         "archiver": "^7.0.1",
@@ -124,10 +122,6 @@
 
     "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
 
-    "@types/jsonwebtoken": ["@types/jsonwebtoken@9.0.10", "", { "dependencies": { "@types/ms": "*", "@types/node": "*" } }, "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA=="],
-
-    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
-
     "@types/node": ["@types/node@25.2.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ=="],
 
     "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260208.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260208.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260208.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260208.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260208.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260208.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260208.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260208.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-Uvrv3FciZTvvdSpmaaJscQ3Nut9/IPFkHh5CIy0IuDHIqwCoHvkkTOdIFE/rgMfHkIlQHhnj9oF94kzRu8YnXg=="],
@@ -190,8 +184,6 @@
 
     "buffer-crc32": ["buffer-crc32@1.0.0", "", {}, "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w=="],
 
-    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
-
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
@@ -253,8 +245,6 @@
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
-
-    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
@@ -416,12 +406,6 @@
 
     "json-parse-better-errors": ["json-parse-better-errors@1.0.2", "", {}, "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="],
 
-    "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
-
-    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
-
-    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
-
     "lazystream": ["lazystream@1.0.1", "", { "dependencies": { "readable-stream": "^2.0.5" } }, "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw=="],
 
     "lint-staged": ["lint-staged@16.2.7", "", { "dependencies": { "commander": "^14.0.2", "listr2": "^9.0.5", "micromatch": "^4.0.8", "nano-spawn": "^2.0.0", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.8.1" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow=="],
@@ -431,20 +415,6 @@
     "load-json-file": ["load-json-file@4.0.0", "", { "dependencies": { "graceful-fs": "^4.1.2", "parse-json": "^4.0.0", "pify": "^3.0.0", "strip-bom": "^3.0.0" } }, "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw=="],
 
     "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
-
-    "lodash.includes": ["lodash.includes@4.3.0", "", {}, "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="],
-
-    "lodash.isboolean": ["lodash.isboolean@3.0.3", "", {}, "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="],
-
-    "lodash.isinteger": ["lodash.isinteger@4.0.4", "", {}, "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="],
-
-    "lodash.isnumber": ["lodash.isnumber@3.0.3", "", {}, "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="],
-
-    "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="],
-
-    "lodash.isstring": ["lodash.isstring@4.0.1", "", {}, "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="],
-
-    "lodash.once": ["lodash.once@4.1.1", "", {}, "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="],
 
     "log-update": ["log-update@7.1.0", "", { "dependencies": { "ansi-escapes": "^7.1.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.2", "strip-ansi": "^7.1.2", "wrap-ansi": "^9.0.2" } }, "sha512-y9pi/ZOQQVvTgfRDEHV1Cj4zQUkJZPipEUNOxhn1R6KgmdMs7LKvXWCd9eMVPGJgvYzFLCenecWr0Ps8ChVv2A=="],
 
@@ -463,8 +433,6 @@
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
-
-    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nano-spawn": ["nano-spawn@2.0.0", "", {}, "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "dotenv": "^17.2.4",
     "form-data-encoder": "^4.1.0",
     "formdata-node": "^6.0.3",
-    "jsonwebtoken": "^9.0.3",
     "listr2": "^10.1.0",
     "ofetch": "^1.5.1",
     "zod": "3.25.76 || ^4.3.6"
@@ -35,7 +34,6 @@
   "devDependencies": {
     "@aklinker1/check": "^2.2.0",
     "@types/bun": "^1.3.14",
-    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.2.2",
     "@typescript/native-preview": "^7.0.0-dev.20260208.1",
     "archiver": "^7.0.1",

--- a/src/utils/firefox-auth.ts
+++ b/src/utils/firefox-auth.ts
@@ -1,4 +1,4 @@
-import jwt from 'jsonwebtoken';
+import { signJwt } from './jwt-utils';
 
 /**
  * See https://addons-server.readthedocs.io/en/latest/topics/api/auth.html
@@ -6,14 +6,11 @@ import jwt from 'jsonwebtoken';
 export function createFirefoxJwt(
   issuer: string,
   secret: string,
-  timeout = 30e3,
+  expiresInS = 30,
 ): string {
-  const issuedAt = Math.floor(Date.now() / 1000);
-  const payload = {
-    iss: issuer,
+  return signJwt('HS256', secret, {
+    expiresInS,
+    issuer,
     jti: Math.random().toString(),
-    iat: issuedAt,
-    exp: issuedAt + Math.floor(timeout / 1000),
-  };
-  return jwt.sign(payload, secret ?? '', { algorithm: 'HS256' });
+  });
 }

--- a/src/utils/jwt-utils.ts
+++ b/src/utils/jwt-utils.ts
@@ -2,7 +2,7 @@ import { createHmac, createSign } from 'node:crypto';
 
 const ALG_MAP = {
   RS256: 'RSA-SHA256',
-  HS256: 'HMAC-SHA256',
+  HS256: 'sha256',
 };
 
 type Alg = keyof typeof ALG_MAP;

--- a/src/utils/jwt-utils.ts
+++ b/src/utils/jwt-utils.ts
@@ -1,8 +1,23 @@
-import { createSign } from 'node:crypto';
+import { createHmac, createSign } from 'node:crypto';
 
 const ALG_MAP = {
   RS256: 'RSA-SHA256',
   HS256: 'HMAC-SHA256',
+};
+
+type Alg = keyof typeof ALG_MAP;
+
+type Signer = (alg: Alg, privateKey: string, signingInput: string) => string;
+
+const SYMMETRIC_SIGNER: Signer = (alg, privateKey, signingInput) =>
+  createHmac(ALG_MAP[alg], privateKey).update(signingInput).digest('base64url');
+
+const ASYMMETRIC_SIGNER: Signer = (alg, privateKey, signingInput) =>
+  createSign(ALG_MAP[alg]).update(signingInput).sign(privateKey, 'base64url');
+
+const SIGNER: Record<Alg, Signer> = {
+  RS256: ASYMMETRIC_SIGNER,
+  HS256: SYMMETRIC_SIGNER,
 };
 
 export type JwtPayloadBuilderOptions = {
@@ -55,8 +70,7 @@ export function signJwt(
   const encodedPayload = Buffer.from(JSON.stringify(claims)).toString(
     'base64url',
   );
-  const signature = createSign(ALG_MAP[alg])
-    .update(`${encodedHeader}.${encodedPayload}`)
-    .sign(privateKey, 'base64url');
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  const signature = SIGNER[alg](alg, privateKey, signingInput);
   return `${encodedHeader}.${encodedPayload}.${signature}`;
 }

--- a/src/utils/jwt-utils.ts
+++ b/src/utils/jwt-utils.ts
@@ -1,0 +1,62 @@
+import { createSign } from 'node:crypto';
+
+const ALG_MAP = {
+  RS256: 'RSA-SHA256',
+  HS256: 'HMAC-SHA256',
+};
+
+export type JwtPayloadBuilderOptions = {
+  issuer?: string;
+  subject?: string;
+  expiresInS?: number;
+  audience?: string;
+  [extras: string]: unknown;
+};
+
+export type JwtPayload = {
+  iss?: string;
+  sub?: string;
+  aud?: string;
+  exp?: number;
+  nbf?: number;
+  iat?: number;
+  [extras: string]: unknown;
+};
+
+export function buildJwtPayload(opts: JwtPayloadBuilderOptions): JwtPayload {
+  const {
+    issuer: iss,
+    subject: sub,
+    expiresInS,
+    audience: aud,
+    ...extras
+  } = opts;
+  const iat = extras.iat ? Number(extras.iat) : Math.floor(Date.now() / 1000);
+  return {
+    iat,
+    ...(iss && { iss }),
+    ...(sub && { sub }),
+    ...(aud && { aud }),
+    ...(expiresInS && { exp: iat + expiresInS }),
+    ...extras,
+  };
+}
+
+export function signJwt(
+  alg: keyof typeof ALG_MAP,
+  privateKey: string,
+  payload: JwtPayloadBuilderOptions,
+): string {
+  const claims = buildJwtPayload(payload);
+  const header = { alg, typ: 'JWT' };
+  const encodedHeader = Buffer.from(JSON.stringify(header)).toString(
+    'base64url',
+  );
+  const encodedPayload = Buffer.from(JSON.stringify(claims)).toString(
+    'base64url',
+  );
+  const signature = createSign(ALG_MAP[alg])
+    .update(`${encodedHeader}.${encodedPayload}`)
+    .sign(privateKey, 'base64url');
+  return `${encodedHeader}.${encodedPayload}.${signature}`;
+}


### PR DESCRIPTION
> Apart of #76 

Signing a JWT is quite simple, only 6 lines (ignoring types and helpers).

`jsonwebtoken` and it's dependencies are [236 kb](https://npmx.dev/package/jsonwebtoken), or 2% the install size.  But it is 15/45 total dependencies.

The source code for the implementation (unpacked, typescript) is 1.9 kb.