### PR TITLE
fix: Refactor config validation using code generation and `superstruct`

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,6 +8,16 @@ on:
       - main
 
 jobs:
+  code-gen:
+    name: Generated Code Up-to-date
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: ./.github/actions/setup
+      - run: bun run gen
+      - name: Check for changes
+        run: git diff --exit-code || (git diff && exit 1)
+
   checks:
     name: Checks
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ console.log(results);
 
 ## Options
 
-Refer to the dedicated documentation: [`./docs/config-reference.md`](./docs/config-reference.md)
+Refer to the [Config Reference](./docs/config-reference.md).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -50,45 +50,18 @@ publish-extension \
 
 ## JS Usage
 
-<!-- prettier-ignore -->
 ```js
 import { publishExtension } from 'publish-browser-extension';
 
-publishExtension({
-  dryRun: true,
-  chrome: {
-    zip: 'dist/chrome.zip',
-    extensionId: '<cws-extension-id>',
-    clientId: '<gcp-client-id>',
-    clientSecret: '<gcp-client-secret>',
-    refreshToken: '<gcp-refresh-token>',
-    publishTarget: '<default|trustedTesters>',
-    skipSubmitReview: false,
-  },
-  firefox: {
-    zip: 'dist/firefox.zip',
-    sourcesZip: 'dist/sources.zip',
-    extensionId: '<addons-extension-id>',
-    jwtIssuer: '<addons-jwt-issuer>',
-    jwtSecret: '<addons-jwt-secret>',
-    channel: '<listed|unlisted>',
-  },
-  edge: {
-    zip: 'dist/chrome.zip',
-    productId: '<edge-product-id>',
-    clientId: '<edge-client-id>',
-    apiKey: '<edge-api-key>',
-    skipSubmitReview: false,
-  },
-  opera: {
-    zip: 'dist/opera.zip',
-    packageId: '<opera-package-id>',
-    sessionId: '<opera-session-id>',
-  },
-})
-  .then(results => console.log(results))
-  .catch(err => console.error(err));
+const results = await publishExtension({
+  // ...
+});
+console.log(results);
 ```
+
+## Options
+
+Refer to the dedicated documentation: [`./docs/config-reference.md`](./docs/config-reference.md)
 
 ## Contributing
 

--- a/bun.lock
+++ b/bun.lock
@@ -12,8 +12,6 @@
         "formdata-node": "^6.0.3",
         "listr2": "^10.1.0",
         "ofetch": "^1.5.1",
-        "scule": "^1.3.0",
-        "superstruct": "^2.0.2",
       },
       "devDependencies": {
         "@aklinker1/check": "^2.2.0",
@@ -27,7 +25,9 @@
         "oxlint": "^1.43.0",
         "prettier": "^3.8.1",
         "publint": "^0.3.17",
+        "scule": "^1.3.0",
         "simple-git-hooks": "^2.13.1",
+        "superstruct": "^2.0.2",
         "tsdown": "^0.20.3",
         "typescript": "^5.9.3",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,8 @@
         "formdata-node": "^6.0.3",
         "listr2": "^10.1.0",
         "ofetch": "^1.5.1",
-        "zod": "3.25.76 || ^4.3.6",
+        "scule": "^1.3.0",
+        "superstruct": "^2.0.2",
       },
       "devDependencies": {
         "@aklinker1/check": "^2.2.0",
@@ -20,6 +21,7 @@
         "@types/node": "^25.2.2",
         "@typescript/native-preview": "^7.0.0-dev.20260208.1",
         "archiver": "^7.0.1",
+        "flat": "^6.0.1",
         "lint-staged": "^16.2.7",
         "npm-run-all": "^4.1.5",
         "oxlint": "^1.43.0",
@@ -284,6 +286,8 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "flat": ["flat@6.0.1", "", { "bin": { "flat": "cli.js" } }, "sha512-/3FfIa8mbrg3xE7+wAhWeV+bd7L2Mof+xtZb5dRDKZ+wDvYJK4WDYeIOuOhre5Yv5aQObZrlbRmk3RTSiuQBtw=="],
+
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
@@ -530,6 +534,8 @@
 
     "safe-regex-test": ["safe-regex-test@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-regex": "^1.2.1" } }, "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw=="],
 
+    "scule": ["scule@1.3.0", "", {}, "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g=="],
+
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
@@ -592,6 +598,8 @@
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
+    "superstruct": ["superstruct@2.0.2", "", {}, "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A=="],
+
     "supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
@@ -653,8 +661,6 @@
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "zip-stream": ["zip-stream@6.0.1", "", { "dependencies": { "archiver-utils": "^5.0.0", "compress-commons": "^6.0.2", "readable-stream": "^4.0.0" } }, "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA=="],
-
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,6 @@
         "@types/node": "^25.2.2",
         "@typescript/native-preview": "^7.0.0-dev.20260208.1",
         "archiver": "^7.0.1",
-        "flat": "^6.0.1",
         "lint-staged": "^16.2.7",
         "npm-run-all": "^4.1.5",
         "oxlint": "^1.43.0",
@@ -285,8 +284,6 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
-
-    "flat": ["flat@6.0.1", "", { "bin": { "flat": "cli.js" } }, "sha512-/3FfIa8mbrg3xE7+wAhWeV+bd7L2Mof+xtZb5dRDKZ+wDvYJK4WDYeIOuOhre5Yv5aQObZrlbRmk3RTSiuQBtw=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -234,7 +234,7 @@ The channel to publish to, "listed" or "unlisted"
 
 ### `firefox.compatibility`
 
-Comma-separated list of compatible applications, e.g. "firefox,android"
+Comma-separated list of compatible applications, e.g. "firefox,android" - "firefox" for compatibility with Firefox desktop apps, "android" for Firefox Android apps
 
 - _CLI Flag_: `--firefox-compatibility`
 - _Env Var_: `FIREFOX_COMPATIBILITY`

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -45,7 +45,7 @@ Check authentication, but don't upload the zip or submit for review
 
 ### `chrome.apiVersion`
 
-The API version to use for the Chrome Web Store: "v1.1" or "v2" (default: v1.1)
+The API version to use for the Chrome Web Store: "v1.1" or "v2"
 
 - _CLI Flag_: `--chrome-api-version`
 - _Env Var_: `CHROME_API_VERSION`

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1,0 +1,305 @@
+# Config Reference
+
+<!-- gen-start:config-docs -->
+
+- [`dryRun`](#dryrun)
+- [`chrome.apiVersion`](#chromeapiversion)
+- [`chrome.deployPercentage`](#chromedeploypercentage)
+- [`chrome.extensionId`](#chromeextensionid)
+- [`chrome.skipSubmitReview`](#chromeskipsubmitreview)
+- [`chrome.zip`](#chromezip)
+- [`chrome.cancelPending`](#chromecancelpending) (API v2 only)
+- [`chrome.publisherId`](#chromepublisherid) (API v2 only)
+- [`chrome.publishType`](#chromepublishtype) (API v2 only)
+- [`chrome.serviceAccountClientEmail`](#chromeserviceaccountclientemail) (API v2 only)
+- [`chrome.serviceAccountPrivateKey`](#chromeserviceaccountprivatekey) (API v2 only)
+- [`chrome.skipReview`](#chromeskipreview) (API v2 only)
+- [`chrome.clientId`](#chromeclientid) (Deprecated: API v1.1 only)
+- [`chrome.clientSecret`](#chromeclientsecret) (Deprecated: API v1.1 only)
+- [`chrome.publishTarget`](#chromepublishtarget) (Deprecated: API v1.1 only)
+- [`chrome.refreshToken`](#chromerefreshtoken) (Deprecated: API v1.1 only)
+- [`chrome.reviewExemption`](#chromereviewexemption) (Deprecated: API v1.1 only)
+- [`edge.apiKey`](#edgeapikey)
+- [`edge.clientId`](#edgeclientid)
+- [`edge.productId`](#edgeproductid)
+- [`edge.skipSubmitReview`](#edgeskipsubmitreview)
+- [`edge.zip`](#edgezip)
+- [`firefox.channel`](#firefoxchannel)
+- [`firefox.compatibility`](#firefoxcompatibility)
+- [`firefox.extensionId`](#firefoxextensionid)
+- [`firefox.jwtIssuer`](#firefoxjwtissuer)
+- [`firefox.jwtSecret`](#firefoxjwtsecret)
+- [`firefox.sourcesZip`](#firefoxsourceszip)
+- [`firefox.zip`](#firefoxzip)
+- [`opera.packageId`](#operapackageid)
+- [`opera.sessionId`](#operasessionid)
+- [`opera.skipSubmitReview`](#operaskipsubmitreview)
+- [`opera.zip`](#operazip)
+
+### `dryRun`
+
+Check authentication, but don't upload the zip or submit for review
+
+- _CLI Flag_: `--dry-run`
+- _Env Var_: `DRY_RUN`
+
+### `chrome.apiVersion`
+
+The API version to use for the Chrome Web Store: "v1.1" or "v2" (default: v1.1)
+
+- _CLI Flag_: `--chrome-api-version`
+- _Env Var_: `CHROME_API_VERSION`
+
+### `chrome.deployPercentage`
+
+An integer from 0-100
+
+- _CLI Flag_: `--chrome-deploy-percentage`
+- _Env Var_: `CHROME_DEPLOY_PERCENTAGE`
+
+### `chrome.extensionId`
+
+The ID of the extension to be submitted
+
+- _CLI Flag_: `--chrome-extension-id`
+- _Env Var_: `CHROME_EXTENSION_ID`
+
+### `chrome.skipSubmitReview`
+
+Just upload the extension zip, don't submit it for review or publish it
+
+- _CLI Flag_: `--chrome-skip-submit-review`
+- _Env Var_: `CHROME_SKIP_SUBMIT_REVIEW`
+
+### `chrome.zip`
+
+Path to extension zip to upload
+
+- _CLI Flag_: `--chrome-zip`
+- _Env Var_: `CHROME_ZIP`
+
+### `chrome.cancelPending`
+
+> [!NOTE]
+> API v2 only
+
+Cancel any pending review before submitting the new version
+
+- _CLI Flag_: `--chrome-cancel-pending`
+- _Env Var_: `CHROME_CANCEL_PENDING`
+
+### `chrome.publisherId`
+
+> [!NOTE]
+> API v2 only
+
+Publisher ID who owns the extension
+
+- _CLI Flag_: `--chrome-publisher-id`
+- _Env Var_: `CHROME_PUBLISHER_ID`
+
+### `chrome.publishType`
+
+> [!NOTE]
+> API v2 only
+
+Set to "STAGED_PUBLISH" to not publish the extension immediately after submission
+
+- _CLI Flag_: `--chrome-publish-type`
+- _Env Var_: `CHROME_PUBLISH_TYPE`
+
+### `chrome.serviceAccountClientEmail`
+
+> [!NOTE]
+> API v2 only
+
+Client email of the service account used for authorizing requests to the Chrome Web Store
+
+- _CLI Flag_: `--chrome-service-account-client-email`
+- _Env Var_: `CHROME_SERVICE_ACCOUNT_CLIENT_EMAIL`
+
+### `chrome.serviceAccountPrivateKey`
+
+> [!NOTE]
+> API v2 only
+
+Private key of the service account used for authorizing requests to the Chrome Web Store
+
+- _CLI Flag_: `--chrome-service-account-private-key`
+- _Env Var_: `CHROME_SERVICE_ACCOUNT_PRIVATE_KEY`
+
+### `chrome.skipReview`
+
+> [!NOTE]
+> API v2 only
+
+Some updates, like ad-blocker rule updates, can skip the review process and be published immediately after submission
+
+- _CLI Flag_: `--chrome-skip-review`
+- _Env Var_: `CHROME_SKIP_REVIEW`
+
+### `chrome.clientId`
+
+> [!NOTE]
+> Deprecated: API v1.1 only
+
+Client ID used for authorizing requests to the Chrome Web Store
+
+- _CLI Flag_: `--chrome-client-id`
+- _Env Var_: `CHROME_CLIENT_ID`
+
+### `chrome.clientSecret`
+
+> [!NOTE]
+> Deprecated: API v1.1 only
+
+Client secret used for authorizing requests to the Chrome Web Store
+
+- _CLI Flag_: `--chrome-client-secret`
+- _Env Var_: `CHROME_CLIENT_SECRET`
+
+### `chrome.publishTarget`
+
+> [!NOTE]
+> Deprecated: API v1.1 only
+
+Group to publish to, "default" or "trustedTesters"
+
+- _CLI Flag_: `--chrome-publish-target`
+- _Env Var_: `CHROME_PUBLISH_TARGET`
+
+### `chrome.refreshToken`
+
+> [!NOTE]
+> Deprecated: API v1.1 only
+
+Refresh token used for authorizing requests to the Chrome Web Store
+
+- _CLI Flag_: `--chrome-refresh-token`
+- _Env Var_: `CHROME_REFRESH_TOKEN`
+
+### `chrome.reviewExemption`
+
+> [!NOTE]
+> Deprecated: API v1.1 only
+
+Submit update using expedited review process
+
+- _CLI Flag_: `--chrome-review-exemption`
+- _Env Var_: `CHROME_REVIEW_EXEMPTION`
+
+### `edge.apiKey`
+
+API key used for authorizing requests to Microsofts addon API v1.1
+
+- _CLI Flag_: `--edge-api-key`
+- _Env Var_: `EDGE_API_KEY`
+
+### `edge.clientId`
+
+Client ID used for authorizing requests to Microsofts addon API
+
+- _CLI Flag_: `--edge-client-id`
+- _Env Var_: `EDGE_CLIENT_ID`
+
+### `edge.productId`
+
+Product ID listed on the developer dashboard
+
+- _CLI Flag_: `--edge-product-id`
+- _Env Var_: `EDGE_PRODUCT_ID`
+
+### `edge.skipSubmitReview`
+
+Just upload the extension zip, don't submit it for review or publish it
+
+- _CLI Flag_: `--edge-skip-submit-review`
+- _Env Var_: `EDGE_SKIP_SUBMIT_REVIEW`
+
+### `edge.zip`
+
+Path to extension zip to upload
+
+- _CLI Flag_: `--edge-zip`
+- _Env Var_: `EDGE_ZIP`
+
+### `firefox.channel`
+
+**Default:** `"listed"`
+
+The channel to publish to, "listed" or "unlisted"
+
+- _CLI Flag_: `--firefox-channel`
+- _Env Var_: `FIREFOX_CHANNEL`
+
+### `firefox.compatibility`
+
+Comma-separated list of compatible applications, e.g. "firefox,android"
+
+- _CLI Flag_: `--firefox-compatibility`
+- _Env Var_: `FIREFOX_COMPATIBILITY`
+
+### `firefox.extensionId`
+
+The ID of the extension to be submitted
+
+- _CLI Flag_: `--firefox-extension-id`
+- _Env Var_: `FIREFOX_EXTENSION_ID`
+
+### `firefox.jwtIssuer`
+
+Issuer used for authorizing requests to Addon Store APIs
+
+- _CLI Flag_: `--firefox-jwt-issuer`
+- _Env Var_: `FIREFOX_JWT_ISSUER`
+
+### `firefox.jwtSecret`
+
+Secret used for authorizing requests to Addon Store APIs
+
+- _CLI Flag_: `--firefox-jwt-secret`
+- _Env Var_: `FIREFOX_JWT_SECRET`
+
+### `firefox.sourcesZip`
+
+Path to sources zip to upload
+
+- _CLI Flag_: `--firefox-sources-zip`
+- _Env Var_: `FIREFOX_SOURCES_ZIP`
+
+### `firefox.zip`
+
+Path to extension zip to upload
+
+- _CLI Flag_: `--firefox-zip`
+- _Env Var_: `FIREFOX_ZIP`
+
+### `opera.packageId`
+
+Package ID listed in the package developer URL: https://addons.opera.com/developer/package/<packageId>
+
+- _CLI Flag_: `--opera-package-id`
+- _Env Var_: `OPERA_PACKAGE_ID`
+
+### `opera.sessionId`
+
+Session ID used for authorizing requests to Opera Addons API
+
+- _CLI Flag_: `--opera-session-id`
+- _Env Var_: `OPERA_SESSION_ID`
+
+### `opera.skipSubmitReview`
+
+Just upload the extension zip, don't submit it for review or publish it
+
+- _CLI Flag_: `--opera-skip-submit-review`
+- _Env Var_: `OPERA_SKIP_SUBMIT_REVIEW`
+
+### `opera.zip`
+
+Path to extension zip to upload
+
+- _CLI Flag_: `--opera-zip`
+- _Env Var_: `OPERA_ZIP`
+
+<!-- gen-end:config-docs -->

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@types/node": "^25.2.2",
     "@typescript/native-preview": "^7.0.0-dev.20260208.1",
     "archiver": "^7.0.1",
-    "flat": "^6.0.1",
     "lint-staged": "^16.2.7",
     "npm-run-all": "^4.1.5",
     "oxlint": "^1.43.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "check": "check",
     "build": "run-s build:*",
-    "build:lib": "tsdown src/index.ts src/cli.ts",
+    "build:lib": "tsdown src/index.ts src/cli.ts --inlineOnly superstruct",
     "build:test-extension": "bun scripts/build-test-extension.js",
     "dev:all": "bun ./scripts/dev.mjs all",
     "dev:chrome": "bun ./scripts/dev.mjs chrome",
@@ -33,9 +33,7 @@
     "form-data-encoder": "^4.1.0",
     "formdata-node": "^6.0.3",
     "listr2": "^10.1.0",
-    "ofetch": "^1.5.1",
-    "scule": "^1.3.0",
-    "superstruct": "^2.0.2"
+    "ofetch": "^1.5.1"
   },
   "devDependencies": {
     "@aklinker1/check": "^2.2.0",
@@ -49,7 +47,9 @@
     "oxlint": "^1.43.0",
     "prettier": "^3.8.1",
     "publint": "^0.3.17",
+    "scule": "^1.3.0",
     "simple-git-hooks": "^2.13.1",
+    "superstruct": "^2.0.2",
     "tsdown": "^0.20.3",
     "typescript": "^5.9.3"
   },

--- a/package.json
+++ b/package.json
@@ -17,9 +17,14 @@
     "publish-extension": "bun src/cli.ts",
     "prepack": "bun run build",
     "prepare": "simple-git-hooks",
-    "gen:cws": "bun run --sequential 'gen:cws:*'",
-    "gen:cws:v1.1": "bun run scripts/gen-cws-api.ts v1.1",
-    "gen:cws:v2": "bun run scripts/gen-cws-api.ts v2"
+    "gen": "bun run --sequential 'gen:*'",
+    "gen:config-docs": "bun run scripts/gen-config-docs.ts",
+    "gen:config-env": "bun run scripts/gen-config-env.ts",
+    "gen:resolve-config": "bun run scripts/gen-resolve-config.ts",
+    "gen:cli-flags": "bun run scripts/gen-cli-flags.ts",
+    "gen:config-from-flags": "bun run scripts/gen-config-from-flags.ts",
+    "gen:cws-v1.1": "bun run scripts/gen-cws-api.ts v1.1",
+    "gen:cws-v2": "bun run scripts/gen-cws-api.ts v2"
   },
   "dependencies": {
     "cac": "^6.7.14",
@@ -29,7 +34,8 @@
     "formdata-node": "^6.0.3",
     "listr2": "^10.1.0",
     "ofetch": "^1.5.1",
-    "zod": "3.25.76 || ^4.3.6"
+    "scule": "^1.3.0",
+    "superstruct": "^2.0.2"
   },
   "devDependencies": {
     "@aklinker1/check": "^2.2.0",
@@ -37,6 +43,7 @@
     "@types/node": "^25.2.2",
     "@typescript/native-preview": "^7.0.0-dev.20260208.1",
     "archiver": "^7.0.1",
+    "flat": "^6.0.1",
     "lint-staged": "^16.2.7",
     "npm-run-all": "^4.1.5",
     "oxlint": "^1.43.0",

--- a/scripts/gen-cli-flags.ts
+++ b/scripts/gen-cli-flags.ts
@@ -2,15 +2,15 @@ import { kebabCase, camelCase } from 'scule';
 import { replaceGeneratedContent } from './utils/code-gen-utils';
 import { configMetas, getDefaultValue } from './utils/config-meta';
 
-const lines: string[] = ['// prettier-ignore', '{'];
-
-for (const meta of configMetas) {
-  const defaultValue = getDefaultValue(meta.schema);
-  const description = `${meta.note ? `[${meta.note}] ` : ''}${meta.description}${defaultValue != null ? ` (default: ${JSON.stringify(defaultValue)})` : ''}`;
-  lines.push(
-    `  cli.option('--${kebabCase(meta.path)} [${camelCase(meta.path)}]', ${JSON.stringify(description)})`,
-  );
-}
-lines.push('}');
+const lines: string[] = [
+  '// prettier-ignore',
+  '{',
+  ...configMetas.map(meta => {
+    const defaultValue = getDefaultValue(meta.schema);
+    const description = `${meta.note ? `[${meta.note}] ` : ''}${meta.description}${defaultValue != null ? ` (default: ${JSON.stringify(defaultValue)})` : ''}`;
+    return `  cli.option('--${kebabCase(meta.path)} [${camelCase(meta.path)}]', ${JSON.stringify(description)})`;
+  }),
+  '}',
+];
 
 await replaceGeneratedContent('src/cli.ts', 'cli-flags', lines.join('\n'));

--- a/scripts/gen-cli-flags.ts
+++ b/scripts/gen-cli-flags.ts
@@ -1,0 +1,16 @@
+import { kebabCase, camelCase } from 'scule';
+import { replaceGeneratedContent } from './utils/code-gen-utils';
+import { configMetas, getDefaultValue } from './utils/config-meta';
+
+const lines: string[] = ['// prettier-ignore', '{'];
+
+for (const meta of configMetas) {
+  const defaultValue = getDefaultValue(meta.schema);
+  const description = `${meta.note ? `[${meta.note}] ` : ''}${meta.description}${defaultValue != null ? ` (default: ${JSON.stringify(defaultValue)})` : ''}`;
+  lines.push(
+    `  cli.option('--${kebabCase(meta.path)} [${camelCase(meta.path)}]', ${JSON.stringify(description)})`,
+  );
+}
+lines.push('}');
+
+await replaceGeneratedContent('src/cli.ts', 'cli-flags', lines.join('\n'));

--- a/scripts/gen-config-docs.ts
+++ b/scripts/gen-config-docs.ts
@@ -1,0 +1,36 @@
+import { kebabCase, flatCase, snakeCase } from 'scule';
+import { configMetas, getDefaultValue } from './utils/config-meta';
+import { replaceGeneratedContent } from './utils/code-gen-utils';
+
+const lines = [
+  '',
+  // TOC
+  ...configMetas.map(
+    meta =>
+      `- [\`${meta.path}\`](#${flatCase(meta.path)})${meta.note ? ` (${meta.note})` : ''}`,
+  ),
+  '',
+  // Sections
+  ...configMetas.flatMap(meta => {
+    const defaultValue = getDefaultValue(meta.schema);
+    return [
+      `### \`${meta.path}\``,
+      ...(meta.note ? [`> [!NOTE]`, `> ${meta.note}`, ''] : []),
+      '',
+      ...(defaultValue
+        ? [`**Default:** \`${JSON.stringify(defaultValue)}\``, '']
+        : []),
+      meta.description,
+      '',
+      `- _CLI Flag_: \`--${kebabCase(meta.path)}\``,
+      `- _Env Var_: \`${snakeCase(meta.path).toUpperCase()}\``,
+    ];
+  }),
+  '',
+];
+
+await replaceGeneratedContent(
+  'docs/config-reference.md',
+  'config-docs',
+  lines.join('\n'),
+);

--- a/scripts/gen-config-env.ts
+++ b/scripts/gen-config-env.ts
@@ -1,0 +1,20 @@
+import { snakeCase } from 'scule';
+import { replaceGeneratedContent } from './utils/code-gen-utils';
+import { configMetas } from './utils/config-meta';
+
+const lines: string[] = [];
+
+lines.push('export interface CustomEnv {');
+for (const meta of configMetas) {
+  lines.push(
+    `  /** ${meta.note ? `[${meta.note}] ` : ''}${meta.description} */`,
+    `  ${snakeCase(meta.path).toUpperCase()}: string | undefined,`,
+  );
+}
+lines.push('}');
+
+await replaceGeneratedContent(
+  'src/utils/env-utils.ts',
+  'config-env',
+  lines.join('\n'),
+);

--- a/scripts/gen-config-from-flags.ts
+++ b/scripts/gen-config-from-flags.ts
@@ -1,0 +1,26 @@
+import { camelCase } from 'scule';
+import { replaceGeneratedContent } from './utils/code-gen-utils';
+import { configMetas, nestedPaths } from './utils/config-meta';
+
+const lines: string[] = [
+  '// prettier-ignore',
+  'function configFromFlags(flags: any): InlineConfig {',
+  '  const config: any = {}',
+  '',
+  '  // Init store objects',
+  ...nestedPaths.map(path => `  config.${path} ??= {}`),
+  '',
+  '  // Set values',
+  ...configMetas.map(
+    meta => `  config.${meta.path} = flags.${camelCase(meta.path)}`,
+  ),
+  '',
+  '  return config',
+  '}',
+];
+
+await replaceGeneratedContent(
+  'src/cli.ts',
+  'config-from-flags',
+  lines.join('\n'),
+);

--- a/scripts/gen-cws-api.ts
+++ b/scripts/gen-cws-api.ts
@@ -1,4 +1,4 @@
-import { format } from 'prettier';
+import { formatCode } from './utils/formatting';
 
 const version = (process.argv[2] ?? 'v2') as 'v1.1' | 'v2';
 const url = `https://chromewebstore.googleapis.com/$discovery/rest?version=${version}`;
@@ -21,7 +21,7 @@ const mod = [
 ];
 
 const outputFile = `src/apis/cws-api-${version}.gen.ts`;
-const formatted = await format(mod.join('\n\n'), { filepath: outputFile });
+const formatted = await formatCode(outputFile, mod.join('\n\n'));
 await Bun.write(outputFile, formatted);
 
 namespace DiscoveryDoc {

--- a/scripts/gen-resolve-config.ts
+++ b/scripts/gen-resolve-config.ts
@@ -25,7 +25,13 @@ const renderValue = (
   meta: { path: string; default?: any },
   padding = allPathsPadding,
 ) =>
-  `(config as any)?.${meta.path.replaceAll('.', '?.').padEnd(padding + 1)} ?? process.env.${snakeCase(meta.path).toUpperCase().padEnd(padding)}${meta.default == null ? `` : ` ?? ${JSON.stringify(meta.default)}`}`;
+  `(config as any)?.${meta.path.replaceAll('.', '?.').padEnd(padding + 1)} ?? process.env.${snakeCase(
+    meta.path,
+  )
+    .toUpperCase()
+    .padEnd(
+      meta.default == null ? 0 : padding,
+    )}${meta.default == null ? `` : ` ?? ${JSON.stringify(meta.default)}`}`;
 
 const lines: string[] = [
   `// prettier-ignore`,

--- a/scripts/gen-resolve-config.ts
+++ b/scripts/gen-resolve-config.ts
@@ -1,0 +1,68 @@
+import { replaceGeneratedContent } from './utils/code-gen-utils';
+import { configMetas } from './utils/config-meta';
+import { snakeCase } from 'scule';
+
+const nestedPaths = [
+  ...new Set(
+    configMetas
+      .map(meta => meta.path.split('.').slice(0, -1))
+      .filter(path => path.length > 0)
+      .map(parts => parts.join(''))
+      .toSorted(),
+  ),
+];
+const storeNamePadding = nestedPaths.reduce(
+  (max, path) => Math.max(max, path.length),
+  0,
+);
+
+const allPathsPadding = configMetas.reduce(
+  (max, meta) => Math.max(max, meta.path.length),
+  0,
+);
+
+const renderValue = (
+  meta: { path: string; default?: any },
+  padding = allPathsPadding,
+) =>
+  `(config as any)?.${meta.path.replaceAll('.', '?.').padEnd(padding + 1)} ?? process.env.${snakeCase(meta.path).toUpperCase().padEnd(padding)}${meta.default == null ? `` : ` ?? ${JSON.stringify(meta.default)}`}`;
+
+const lines: string[] = [
+  `// prettier-ignore`,
+  `/**`,
+  ` * Given inline config, read environment variables and apply defaults. Throws an`,
+  ` * error if any config is missing.`,
+  ` */`,
+  `export function resolveConfig(config?: InlineConfig): ResolvedConfig {`,
+  `  const raw: Record<string, any> = {}`,
+  ``,
+  '  // Init store objects',
+  ...nestedPaths.map(
+    path =>
+      `  const ${(path + 'Zip').padEnd(storeNamePadding + 3)} = ${renderValue({ path: path + '.zip' }, storeNamePadding + 4)}`,
+  ),
+  ``,
+  ...nestedPaths.map(
+    path =>
+      `  if ${('(' + path + 'Zip)').padEnd(storeNamePadding + 5)} raw.${path.padEnd(storeNamePadding)} ??= {}`,
+  ),
+  ``,
+  '  // Set values',
+  ...configMetas.map(meta => {
+    const parentParts = meta.path.split('.').slice(0, -1);
+    const ifStatement =
+      parentParts.length === 0
+        ? ''
+        : `if ${('(raw.' + parentParts.join('.') + ')').padEnd(storeNamePadding + 6)} `;
+    return `  ${ifStatement}raw.${meta.path.padEnd(allPathsPadding)} = ${renderValue(meta)}`;
+  }),
+  ``,
+  `  return validateConfig(raw);`,
+  `}`,
+];
+
+await replaceGeneratedContent(
+  'src/config.ts',
+  'config-resolver',
+  lines.join('\n'),
+);

--- a/scripts/utils/code-gen-utils.ts
+++ b/scripts/utils/code-gen-utils.ts
@@ -1,7 +1,7 @@
 import { extname } from 'node:path';
-import { format } from 'prettier';
+import { formatCode } from './formatting';
 
-const comments: Record<string, (str: string) => string> = {
+const COMMENTS: Record<string, (str: string) => string> = {
   '.md': str => `<!-- ${str} -->`,
   '.ts': str => `/// ${str}`,
 };
@@ -13,7 +13,7 @@ export async function replaceGeneratedContent(
 ): Promise<void> {
   const file = Bun.file(path);
   const ext = extname(path);
-  const getComment = comments[ext];
+  const getComment = COMMENTS[ext];
   if (!getComment) throw Error(`Unsupported file extension: ${ext}`);
 
   const content = await file.text();
@@ -29,7 +29,7 @@ export async function replaceGeneratedContent(
   const updatedContent =
     content.slice(0, startIndex) + replacement + content.slice(endIndex);
 
-  const formatted = await format(updatedContent, { filepath: path });
+  const formatted = await formatCode(path, updatedContent);
 
   await file.write(formatted);
 }

--- a/scripts/utils/code-gen-utils.ts
+++ b/scripts/utils/code-gen-utils.ts
@@ -1,0 +1,35 @@
+import { extname } from 'node:path';
+import { format } from 'prettier';
+
+const comments: Record<string, (str: string) => string> = {
+  '.md': str => `<!-- ${str} -->`,
+  '.ts': str => `/// ${str}`,
+};
+
+export async function replaceGeneratedContent(
+  path: string,
+  block: string,
+  replacement: string,
+): Promise<void> {
+  const file = Bun.file(path);
+  const ext = extname(path);
+  const getComment = comments[ext];
+  if (!getComment) throw Error(`Unsupported file extension: ${ext}`);
+
+  const content = await file.text();
+  const startComment = getComment(`gen-start:${block}`);
+
+  const startIndex = content.indexOf(startComment) + startComment.length + 1;
+  if (startIndex === -1) return;
+
+  const endComment = getComment(`gen-end:${block}`);
+  let endIndex = content.indexOf(endComment, startIndex) - 1;
+  if (endIndex === -1) endIndex = content.length;
+
+  const updatedContent =
+    content.slice(0, startIndex) + replacement + content.slice(endIndex);
+
+  const formatted = await format(updatedContent, { filepath: path });
+
+  await file.write(formatted);
+}

--- a/scripts/utils/config-meta.ts
+++ b/scripts/utils/config-meta.ts
@@ -8,7 +8,7 @@ import {
   ResolvedConfig,
   isMetaStruct,
   type MetaStruct,
-} from '../../src/utils/config-definitions';
+} from '../../src/utils/config-schema';
 
 const schemasWithOptions = [
   ...Object.values(ResolvedConfig.schema),

--- a/scripts/utils/config-meta.ts
+++ b/scripts/utils/config-meta.ts
@@ -47,10 +47,9 @@ export const nestedPaths = [
     configMetas
       .map(meta => meta.path.split('.').slice(0, -1))
       .filter(path => path.length > 0)
-      .map(parts => parts.join(''))
-      .toSorted(),
+      .map(parts => parts.join('')),
   ),
-];
+].toSorted();
 
 export function getDefaultValue<T>(schema: Struct<T>): T {
   const [_, defaultValue] = validate(undefined!, schema, { coerce: true });

--- a/scripts/utils/config-meta.ts
+++ b/scripts/utils/config-meta.ts
@@ -1,0 +1,58 @@
+import { validate, type Struct } from 'superstruct';
+import {
+  ChromeWebStoreV2Options,
+  ChromeWebStoreV1_1Options,
+  EdgeAddonStoreV1_1Options,
+  FirefoxAddonStoreV5Options,
+  OperaAddonsStoreOptions,
+  ResolvedConfig,
+  isMetaStruct,
+  type MetaStruct,
+} from '../../src/utils/config-definitions';
+
+const schemasWithOptions = [
+  ...Object.values(ResolvedConfig.schema),
+  ...Object.values(ChromeWebStoreV2Options.schema),
+  ...Object.values(ChromeWebStoreV1_1Options.schema),
+  ...Object.values(EdgeAddonStoreV1_1Options.schema),
+  ...Object.values(FirefoxAddonStoreV5Options.schema),
+  ...Object.values(OperaAddonsStoreOptions.schema),
+].filter(schema => isMetaStruct(schema as Struct<any>)) as MetaStruct<any>[];
+
+const seenPaths = new Set<string>();
+
+export const configMetas = schemasWithOptions
+  .toSorted(
+    (a, b) =>
+      // dryRun first
+      a['~meta'].path.split('.').length - b['~meta'].path.split('.').length ||
+      // Next, sort by store name
+      a['~meta'].path
+        .split('.')[0]!
+        .localeCompare(b['~meta'].path.split('.')[0]!) ||
+      // Then group by note
+      (a['~meta'].note ?? '').localeCompare(b['~meta'].note ?? '') ||
+      // Finally, alphabetical order
+      a['~meta'].path.localeCompare(b['~meta'].path),
+  )
+  .filter(
+    schema =>
+      !seenPaths.has(schema['~meta'].path) &&
+      seenPaths.add(schema['~meta'].path),
+  )
+  .map(schema => ({ ...schema['~meta'], schema }));
+
+export const nestedPaths = [
+  ...new Set(
+    configMetas
+      .map(meta => meta.path.split('.').slice(0, -1))
+      .filter(path => path.length > 0)
+      .map(parts => parts.join(''))
+      .toSorted(),
+  ),
+];
+
+export function getDefaultValue<T>(schema: Struct<T>): T {
+  const [_, defaultValue] = validate(undefined!, schema, { coerce: true });
+  return defaultValue as T;
+}

--- a/scripts/utils/formatting.ts
+++ b/scripts/utils/formatting.ts
@@ -1,0 +1,6 @@
+import prettierConfig from '../../.prettierrc.yml';
+import { format } from 'prettier';
+
+export function formatCode(path: string, content: string): Promise<string> {
+  return format(content, { filepath: path, ...prettierConfig });
+}

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -5,6 +5,7 @@ import {
   resolveConfig,
   validateConfig,
 } from '../config';
+import type { FirefoxAddonStoreV5Options } from '../utils/config-schema';
 
 const RESET_ENV_NAMES = /(^CHROME_|^FIREFOX_|^EDGE_|^OPERA_|^DRY_RUN$)/;
 
@@ -90,6 +91,11 @@ describe('resolveConfig', () => {
     process.env.FIREFOX_JWT_SECRET = 'FIREFOX_JWT_SECRET';
     const firefoxChannel = 'unlisted';
     process.env.FIREFOX_CHANNEL = firefoxChannel;
+    const firefoxCompatibility: FirefoxAddonStoreV5Options['compatibility'] = [
+      'android',
+      'firefox',
+    ];
+    process.env.FIREFOX_COMPATIBILITY = firefoxCompatibility.join(',');
 
     process.env.EDGE_ZIP = 'EDGE_ZIP';
     process.env.EDGE_PRODUCT_ID = 'EDGE_PRODUCT_ID';
@@ -129,6 +135,7 @@ describe('resolveConfig', () => {
         extensionId: process.env.FIREFOX_EXTENSION_ID,
         jwtIssuer: process.env.FIREFOX_JWT_ISSUER,
         jwtSecret: process.env.FIREFOX_JWT_SECRET,
+        compatibility: firefoxCompatibility,
       },
       edge: {
         zip: process.env.EDGE_ZIP,

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach } from 'bun:test';
 import {
-  InlineConfig,
-  InternalConfig,
+  type InlineConfig,
+  type ResolvedConfig,
   resolveConfig,
   validateConfig,
-} from './config';
+} from '../config';
 
 const RESET_ENV_NAMES = /(^CHROME_|^FIREFOX_|^EDGE_|^OPERA_|^DRY_RUN$)/;
 
@@ -55,7 +55,7 @@ describe('resolveConfig', () => {
         sessionId: 'sessionId',
         skipSubmitReview: true,
       },
-    } satisfies InternalConfig;
+    } satisfies ResolvedConfig;
 
     const actual = resolveConfig(config);
 
@@ -105,7 +105,7 @@ describe('resolveConfig', () => {
     const operaSkipSubmitReview = true;
     process.env.OPERA_SKIP_SUBMIT_REVIEW = String(operaSkipSubmitReview);
 
-    const expected: InternalConfig = {
+    const expected: ResolvedConfig = {
       dryRun,
       chrome: {
         apiVersion: 'v2',
@@ -202,7 +202,7 @@ describe('resolveConfig', () => {
         ...config.opera,
         skipSubmitReview: false,
       },
-    };
+    } as ResolvedConfig;
 
     const actual = resolveConfig(config);
 
@@ -225,7 +225,7 @@ describe('resolveConfig', () => {
         packageId: 1,
       },
     };
-    const expected: InternalConfig = {
+    const expected: ResolvedConfig = {
       dryRun: false,
       chrome: undefined,
       edge: undefined,
@@ -245,10 +245,11 @@ describe('validateConfig', () => {
       dryRun: true,
       chrome: {
         apiVersion: 'v2',
+        extensionId: ' ',
       },
     };
     expect(() => validateConfig(config)).toThrowError(
-      'Missing required config: CHROME_ZIP, CHROME_EXTENSION_ID, CHROME_PUBLISHER_ID, CHROME_SERVICE_ACCOUNT_CLIENT_EMAIL, CHROME_SERVICE_ACCOUNT_PRIVATE_KEY',
+      'Invalid config:\n  - `chrome.zip`: Expected a string, but received: undefined\n  - `chrome.extensionId`: Expected a nonempty string but received an empty one\n  - `chrome.publisherId`: Expected a string, but received: undefined\n  - `chrome.serviceAccountClientEmail`: Expected a string, but received: undefined\n  - `chrome.serviceAccountPrivateKey`: Expected a string, but received: undefined',
     );
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,7 +40,7 @@ cli.help();
   cli.option('--edge-skip-submit-review [edgeSkipSubmitReview]', "Just upload the extension zip, don't submit it for review or publish it (default: false)")
   cli.option('--edge-zip [edgeZip]', "Path to extension zip to upload")
   cli.option('--firefox-channel [firefoxChannel]', "The channel to publish to, \"listed\" or \"unlisted\" (default: \"listed\")")
-  cli.option('--firefox-compatibility [firefoxCompatibility]', "Comma-separated list of compatible applications, e.g. \"firefox,android\"")
+  cli.option('--firefox-compatibility [firefoxCompatibility]', "Comma-separated list of compatible applications, e.g. \"firefox,android\" - \"firefox\" for compatibility with Firefox desktop apps, \"android\" for Firefox Android apps")
   cli.option('--firefox-extension-id [firefoxExtensionId]', "The ID of the extension to be submitted")
   cli.option('--firefox-jwt-issuer [firefoxJwtIssuer]', "Issuer used for authorizing requests to Addon Store APIs")
   cli.option('--firefox-jwt-secret [firefoxJwtSecret]', "Secret used for authorizing requests to Addon Store APIs")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,12 +1,10 @@
 import { cac } from 'cac';
 import { version } from '../package.json';
 import { submit } from './commands/submit';
-import { InlineConfig, type AllChromeOptions } from './config';
 import { init } from './commands/init';
 import { consola } from 'consola';
 import { config } from 'dotenv';
-import type { ChromeWebStoreV1_1Options } from './stores/chrome-web-store-v1.1';
-import type { ChromeWebStoreV2Options } from './stores/chrome-web-store-v2';
+import type { InlineConfig } from './config';
 import { status } from './commands/status';
 import { setDeployPercentage } from './commands/set-deploy-percentage';
 
@@ -16,206 +14,116 @@ const cli = cac('publish-extension');
 cli.version(version);
 cli.help();
 
-// All stores
-cli.option(
-  '--dry-run',
-  "Check authentication, but don't upload the zip or submit for review",
-);
-// Chrome (shared)
-cli.option('--chrome-zip [chromeZip]', 'Path to extension zip to upload');
-cli.option(
-  '--chrome-extension-id [chromeExtensionId]',
-  'The ID of the extension to be submitted',
-);
-cli.option(
-  '--chrome-api-version [chromeApiVersion]',
-  'The API version to use for the Chrome Web Store: "v1.1" or "v2" (default: v1.1)',
-);
-cli.option(
-  '--chrome-deploy-percentage [chromeDeployPercentage]',
-  'An integer from 1-100',
-);
-cli.option(
-  '--chrome-skip-submit-review',
-  "Just upload the extension zip, don't submit it for review or publish it",
-);
-// Chrome (v1.1)
-cli.option(
-  '--chrome-client-id [chromeClientId]',
-  '[api v1.1 only] Client ID used for authorizing requests to the Chrome Web Store',
-);
-cli.option(
-  '--chrome-client-secret [chromeClientSecret]',
-  '[api v1.1 only] Client secret used for authorizing requests to the Chrome Web Store',
-);
-cli.option(
-  '--chrome-refresh-token [chromeRefreshToken]',
-  '[api v1.1 only] Refresh token used for authorizing requests to the Chrome Web Store',
-);
-cli.option(
-  '--chrome-publish-target [chromePublishTarget]',
-  '[api v1.1 only] Group to publish to, "default" or "trustedTesters"',
-);
-cli.option(
-  '--chrome-review-exemption',
-  '[api v1.1 only] Submit update using expedited review process',
-);
-// Chrome (v2)
-cli.option(
-  '--chrome-publisher-id [chromePublisherId]',
-  '[api v2 only] Publisher ID who owns the extension',
-);
-cli.option(
-  '--chrome-service-account-client-email [chromeServiceAccountClientEmail]',
-  '[api v2 only] Client email of the service account used for authorizing requests to the Chrome Web Store',
-);
-cli.option(
-  '--chrome-service-account-private-key [chromeServiceAccountPrivateKey]',
-  '[api v2 only] Private key of the service account used for authorizing requests to the Chrome Web Store',
-);
-cli.option(
-  '--chrome-skip-review',
-  '[api v2 only] Some updates, like ad-blocker rule updates, can skip the review process and be published immediately after submission',
-);
-cli.option(
-  '--chrome-publish-type [chromePublishType]',
-  '[api v2 only] Set to "STAGED_PUBLISH" to not publish the extension immediately after submission',
-);
-cli.option(
-  '--chrome-cancel-pending',
-  '[api v2 only] Cancel any pending review before submitting the new version',
-);
-// Firefox
-cli.option('--firefox-zip [firefoxZip]', 'Path to extension zip to upload');
-cli.option(
-  '--firefox-sources-zip [firefoxSourcesZip]',
-  'Path to sources zip to upload',
-);
-cli.option(
-  '--firefox-extension-id [firefoxExtensionId]',
-  'The ID of the extension to be submitted',
-);
-cli.option(
-  '--firefox-jwt-issuer [firefoxJwtIssuer]',
-  'Issuer used for authorizing requests to Addon Store APIs',
-);
-cli.option(
-  '--firefox-jwt-secret [firefoxJwtSecret]',
-  'Secret used for authorizing requests to Addon Store APIs',
-);
-cli.option(
-  '--firefox-channel [firefoxChannel]',
-  'The channel to publish to, "listed" or "unlisted"',
-);
-cli.option(
-  '--firefox-compatibility [firefoxCompatibility]',
-  'Comma-separated list of compatible applications, e.g. "firefox,android"',
-);
-// Edge
-cli.option('--edge-zip [edgeZip]', 'Path to extension zip to upload');
-cli.option(
-  '--edge-product-id [edgeProductId]',
-  'Product ID listed on the developer dashboard',
-);
-cli.option(
-  '--edge-client-id [edgeClientId]',
-  'Client ID used for authorizing requests to Microsofts addon API',
-);
-cli.option(
-  '--edge-api-key [edgeApiKey]',
-  'API key used for authorizing requests to Microsofts addon API v1.1',
-);
-cli.option(
-  '--edge-client-secret [edgeClientSecret]',
-  'DEPRECATED: Client secret used for authorizing requests to Microsofts addon API v1.0 (no longer available)',
-);
-cli.option(
-  '--edge-access-token-url [edgeAccessTokenUrl]',
-  'DEPRECATED: Access token URL used for authorizing requests to Microsofts addon API v1.0 (no longer available)',
-);
-cli.option(
-  '--edge-skip-submit-review',
-  "Just upload the extension zip, don't submit it for review or publish it",
-);
-// Opera
-cli.option('--opera-zip [operaZip]', 'Path to extension zip to upload');
-cli.option(
-  '--opera-package-id [packageId]',
-  'Package ID listed in the package developer URL: https://addons.opera.com/developer/package/<packageId>',
-);
-cli.option(
-  '--opera-session-id [sessionId]',
-  'Session ID used for authorizing requests to Opera Addons API',
-);
-cli.option(
-  '--opera-skip-submit-review',
-  "Just upload the extension zip, don't submit it for review or publish it",
-);
+/// gen-start:cli-flags
+// prettier-ignore
+{
+  cli.option('--dry-run [dryRun]', "Check authentication, but don't upload the zip or submit for review (default: false)")
+  cli.option('--chrome-api-version [chromeApiVersion]', "The API version to use for the Chrome Web Store: \"v1.1\" or \"v2\" (default: v1.1)")
+  cli.option('--chrome-deploy-percentage [chromeDeployPercentage]', "An integer from 0-100")
+  cli.option('--chrome-extension-id [chromeExtensionId]', "The ID of the extension to be submitted")
+  cli.option('--chrome-skip-submit-review [chromeSkipSubmitReview]', "Just upload the extension zip, don't submit it for review or publish it (default: false)")
+  cli.option('--chrome-zip [chromeZip]', "Path to extension zip to upload")
+  cli.option('--chrome-cancel-pending [chromeCancelPending]', "[API v2 only] Cancel any pending review before submitting the new version (default: false)")
+  cli.option('--chrome-publisher-id [chromePublisherId]', "[API v2 only] Publisher ID who owns the extension")
+  cli.option('--chrome-publish-type [chromePublishType]', "[API v2 only] Set to \"STAGED_PUBLISH\" to not publish the extension immediately after submission")
+  cli.option('--chrome-service-account-client-email [chromeServiceAccountClientEmail]', "[API v2 only] Client email of the service account used for authorizing requests to the Chrome Web Store")
+  cli.option('--chrome-service-account-private-key [chromeServiceAccountPrivateKey]', "[API v2 only] Private key of the service account used for authorizing requests to the Chrome Web Store")
+  cli.option('--chrome-skip-review [chromeSkipReview]', "[API v2 only] Some updates, like ad-blocker rule updates, can skip the review process and be published immediately after submission")
+  cli.option('--chrome-client-id [chromeClientId]', "[Deprecated: API v1.1 only] Client ID used for authorizing requests to the Chrome Web Store")
+  cli.option('--chrome-client-secret [chromeClientSecret]', "[Deprecated: API v1.1 only] Client secret used for authorizing requests to the Chrome Web Store")
+  cli.option('--chrome-publish-target [chromePublishTarget]', "[Deprecated: API v1.1 only] Group to publish to, \"default\" or \"trustedTesters\"")
+  cli.option('--chrome-refresh-token [chromeRefreshToken]', "[Deprecated: API v1.1 only] Refresh token used for authorizing requests to the Chrome Web Store")
+  cli.option('--chrome-review-exemption [chromeReviewExemption]', "[Deprecated: API v1.1 only] Submit update using expedited review process")
+  cli.option('--edge-api-key [edgeApiKey]', "API key used for authorizing requests to Microsofts addon API v1.1")
+  cli.option('--edge-client-id [edgeClientId]', "Client ID used for authorizing requests to Microsofts addon API")
+  cli.option('--edge-product-id [edgeProductId]', "Product ID listed on the developer dashboard")
+  cli.option('--edge-skip-submit-review [edgeSkipSubmitReview]', "Just upload the extension zip, don't submit it for review or publish it (default: false)")
+  cli.option('--edge-zip [edgeZip]', "Path to extension zip to upload")
+  cli.option('--firefox-channel [firefoxChannel]', "The channel to publish to, \"listed\" or \"unlisted\" (default: \"listed\")")
+  cli.option('--firefox-compatibility [firefoxCompatibility]', "Comma-separated list of compatible applications, e.g. \"firefox,android\"")
+  cli.option('--firefox-extension-id [firefoxExtensionId]', "The ID of the extension to be submitted")
+  cli.option('--firefox-jwt-issuer [firefoxJwtIssuer]', "Issuer used for authorizing requests to Addon Store APIs")
+  cli.option('--firefox-jwt-secret [firefoxJwtSecret]', "Secret used for authorizing requests to Addon Store APIs")
+  cli.option('--firefox-sources-zip [firefoxSourcesZip]', "Path to sources zip to upload")
+  cli.option('--firefox-zip [firefoxZip]', "Path to extension zip to upload")
+  cli.option('--opera-package-id [operaPackageId]', "Package ID listed in the package developer URL: https://addons.opera.com/developer/package/<packageId>")
+  cli.option('--opera-session-id [operaSessionId]', "Session ID used for authorizing requests to Opera Addons API")
+  cli.option('--opera-skip-submit-review [operaSkipSubmitReview]', "Just upload the extension zip, don't submit it for review or publish it (default: false)")
+  cli.option('--opera-zip [operaZip]', "Path to extension zip to upload")
+}
+/// gen-end:cli-flags
 
+/// gen-start:config-from-flags
+// prettier-ignore
 function configFromFlags(flags: any): InlineConfig {
-  let operaPackageId: number | undefined = undefined;
+  const config: any = {}
 
-  if (flags.operaPackageId !== undefined) {
-    const parsed = Number(flags.operaPackageId);
+  // Init store objects
+  config.chrome ??= {}
+  config.edge ??= {}
+  config.firefox ??= {}
+  config.opera ??= {}
 
-    if (!Number.isNaN(parsed) && Number.isInteger(parsed) && parsed > 0) {
-      operaPackageId = parsed;
-    } else {
-      consola.warn(
-        `Invalid value for --opera-package-id: "${flags.operaPackageId}". It must be a positive integer.`,
-      );
-    }
-  }
+  // Set values
+  config.dryRun = flags.dryRun
+  config.chrome.apiVersion = flags.chromeApiVersion
+  config.chrome.deployPercentage = flags.chromeDeployPercentage
+  config.chrome.extensionId = flags.chromeExtensionId
+  config.chrome.skipSubmitReview = flags.chromeSkipSubmitReview
+  config.chrome.zip = flags.chromeZip
+  config.chrome.cancelPending = flags.chromeCancelPending
+  config.chrome.publisherId = flags.chromePublisherId
+  config.chrome.publishType = flags.chromePublishType
+  config.chrome.serviceAccountClientEmail = flags.chromeServiceAccountClientEmail
+  config.chrome.serviceAccountPrivateKey = flags.chromeServiceAccountPrivateKey
+  config.chrome.skipReview = flags.chromeSkipReview
+  config.chrome.clientId = flags.chromeClientId
+  config.chrome.clientSecret = flags.chromeClientSecret
+  config.chrome.publishTarget = flags.chromePublishTarget
+  config.chrome.refreshToken = flags.chromeRefreshToken
+  config.chrome.reviewExemption = flags.chromeReviewExemption
+  config.edge.apiKey = flags.edgeApiKey
+  config.edge.clientId = flags.edgeClientId
+  config.edge.productId = flags.edgeProductId
+  config.edge.skipSubmitReview = flags.edgeSkipSubmitReview
+  config.edge.zip = flags.edgeZip
+  config.firefox.channel = flags.firefoxChannel
+  config.firefox.compatibility = flags.firefoxCompatibility
+  config.firefox.extensionId = flags.firefoxExtensionId
+  config.firefox.jwtIssuer = flags.firefoxJwtIssuer
+  config.firefox.jwtSecret = flags.firefoxJwtSecret
+  config.firefox.sourcesZip = flags.firefoxSourcesZip
+  config.firefox.zip = flags.firefoxZip
+  config.opera.packageId = flags.operaPackageId
+  config.opera.sessionId = flags.operaSessionId
+  config.opera.skipSubmitReview = flags.operaSkipSubmitReview
+  config.opera.zip = flags.operaZip
 
-  // TODO: Move back inline in the return once v1.1 support is dropped.
-  const chrome: AllChromeOptions = {
-    // Shared
-    zip: flags.chromeZip,
-    apiVersion: flags.chromeApiVersion,
-    extensionId: flags.chromeExtensionId,
-    deployPercentage: flags.chromeDeployPercentage,
-    skipSubmitReview: flags.chromeSkipSubmitReview,
-    // v1.1
-    clientId: flags.chromeClientId,
-    clientSecret: flags.chromeClientSecret,
-    refreshToken: flags.chromeRefreshToken,
-    publishTarget: flags.chromePublishTarget,
-    reviewExemption: flags.chromeReviewExemption,
-    // v2
-    publisherId: flags.chromePublisherId,
-    skipReview: flags.chromeSkipReview,
-    serviceAccountClientEmail: flags.chromeServiceAccountClientEmail,
-    serviceAccountPrivateKey: flags.chromeServiceAccountPrivateKey,
-    publishType: flags.chromePublishType,
-    cancelPending: flags.chromeCancelPending,
-  };
+  return config
+}
+/// gen-end:config-from-flags
 
-  return {
-    dryRun: flags.dryRun,
-    chrome: chrome as ChromeWebStoreV1_1Options | ChromeWebStoreV2Options,
-    firefox: {
-      zip: flags.firefoxZip,
-      sourcesZip: flags.firefoxSourcesZip,
-      extensionId: flags.firefoxExtensionId,
-      jwtIssuer: flags.firefoxJwtIssuer,
-      jwtSecret: flags.firefoxJwtSecret,
-      channel: flags.firefoxChannel,
-      compatibility: flags.firefoxCompatibility?.split(','),
-    },
-    edge: {
-      zip: flags.edgeZip,
-      productId: flags.edgeProductId,
-      clientId: flags.edgeClientId,
-      apiKey: flags.edgeApiKey,
-      skipSubmitReview: flags.edgeSkipSubmitReview,
-    },
-    opera: {
-      zip: flags.operaZip,
-      packageId: operaPackageId,
-      sessionId: flags.operaSessionId,
-      skipSubmitReview: flags.operaSkipSubmitReview,
-    },
-  };
+/**
+ * Same as `configFromFlags`, but add fake ZIP file paths for stores that don't have a ZIP file specified.
+ *
+ * `resolveConfig` will return `undefined` for store options unless a ZIP file is specified.
+ */
+function configFromFlagsWithFakeZip(
+  flags: any,
+  zips: {
+    chrome?: boolean;
+    firefox?: boolean;
+    edge?: boolean;
+    opera?: boolean;
+  },
+) {
+  return configFromFlags({
+    chromeZip: zips.chrome ? '...' : undefined,
+    firefoxZip: zips.firefox ? '...' : undefined,
+    edgeZip: zips.edge ? '...' : undefined,
+    operaZip: zips.opera ? '...' : undefined,
+    ...flags,
+  });
 }
 
 // SUBMIT
@@ -241,14 +149,11 @@ cli
     'Interactive walkthrough to initialize or update secrets and options for each store',
   )
   .action(async flags => {
-    const config = configFromFlags({
-      // Apply some placeholder flags so all the options resolve correctly (if zip doesn't exist,
-      // none of the related options are included, and init always thinks you haven't entered anything yet)
-      chromeZip: '...',
-      firefoxZip: '...',
-      edgeZip: '...',
-      operaZip: '...',
-      ...flags,
+    const config = configFromFlagsWithFakeZip(flags, {
+      chrome: true,
+      firefox: true,
+      opera: true,
+      edge: true,
     });
 
     try {
@@ -267,7 +172,9 @@ cli
     'Set the deploy percentage for the extension',
   )
   .action(async flags => {
-    const config = configFromFlags(flags);
+    const config = configFromFlagsWithFakeZip(flags, {
+      chrome: true,
+    });
 
     try {
       await setDeployPercentage(config);
@@ -285,7 +192,9 @@ cli
     'Get the current published and submission status of the extension',
   )
   .action(async flags => {
-    const config = configFromFlags(flags);
+    const config = configFromFlagsWithFakeZip(flags, {
+      chrome: true,
+    });
 
     try {
       await status(config);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,7 @@ cli.help();
 // prettier-ignore
 {
   cli.option('--dry-run [dryRun]', "Check authentication, but don't upload the zip or submit for review (default: false)")
-  cli.option('--chrome-api-version [chromeApiVersion]', "The API version to use for the Chrome Web Store: \"v1.1\" or \"v2\" (default: v1.1)")
+  cli.option('--chrome-api-version [chromeApiVersion]', "The API version to use for the Chrome Web Store: \"v1.1\" or \"v2\"")
   cli.option('--chrome-deploy-percentage [chromeDeployPercentage]', "An integer from 0-100")
   cli.option('--chrome-extension-id [chromeExtensionId]', "The ID of the extension to be submitted")
   cli.option('--chrome-skip-submit-review [chromeSkipSubmitReview]', "Just upload the extension zip, don't submit it for review or publish it (default: false)")

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,17 +1,17 @@
 import { consola } from 'consola';
 import {
-  InlineConfig,
+  type EdgeAddonStoreV1_1Options,
+  type ChromeWebStoreV1_1Options,
+  type ChromeWebStoreV2Options,
+  type FirefoxAddonStoreV5Options,
+  type OperaAddonsStoreOptions,
   resolveConfig,
   type AllChromeOptions,
-  type CustomEnv,
+  type InlineConfig,
 } from '../config';
 import { copyFile, writeFile, readFile } from 'node:fs/promises';
-import { ChromeWebStoreV1_1Options } from '../stores/chrome-web-store-v1.1';
-import { ChromeWebStoreV2Options } from '../stores/chrome-web-store-v2';
-import { FirefoxAddonStoreV5Options } from '../stores/firefox-addon-store-v5';
-import { EdgeAddonStoreV1_1Options } from '../stores/edge-addon-store-v1.1';
-import { OperaAddonsStoreOptions } from '../stores/opera-addons-store';
 import { ofetch } from 'ofetch';
+import type { CustomEnv } from '../utils/env-utils';
 
 type Entry = [key: keyof CustomEnv, value: string | number | boolean];
 

--- a/src/commands/set-deploy-percentage.ts
+++ b/src/commands/set-deploy-percentage.ts
@@ -1,9 +1,6 @@
 import consola from 'consola';
-import { resolveChromeV2Options, type InlineConfig } from '../config';
-import {
-  ChromeWebStoreV2,
-  ChromeWebStoreV2Options,
-} from '../stores/chrome-web-store-v2';
+import { resolveConfig, type InlineConfig } from '../config';
+import { ChromeWebStoreV2 } from '../stores/chrome-web-store-v2';
 
 export async function setDeployPercentage(config: InlineConfig): Promise<void> {
   console.log();
@@ -12,17 +9,19 @@ export async function setDeployPercentage(config: InlineConfig): Promise<void> {
   if (config.dryRun)
     throw Error('Dry run is not supported when setting the deploy percentage');
 
-  const resolved = ChromeWebStoreV2Options.parse(
-    resolveChromeV2Options(
-      '...',
-      (config.chrome ?? {}) as ChromeWebStoreV2Options,
-    ),
-  );
+  const { chrome: resolved } = resolveConfig(config);
+  if (!resolved)
+    throw Error(
+      'Chrome options are required when setting the deploy percentage',
+    );
 
   if (resolved.deployPercentage == null)
     throw Error(
       'Deploy percentage is required when setting the deploy percentage',
     );
+
+  if (resolved.apiVersion !== 'v2')
+    throw Error('Only v2 API is supported when setting the deploy percentage');
 
   const store = new ChromeWebStoreV2(resolved, consola.success);
   await store.setDeploymentPercentage(resolved.deployPercentage);

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,9 +1,6 @@
 import consola from 'consola';
-import { resolveChromeV2Options, type InlineConfig } from '../config';
-import {
-  ChromeWebStoreV2,
-  ChromeWebStoreV2Options,
-} from '../stores/chrome-web-store-v2';
+import { resolveConfig, type InlineConfig } from '../config';
+import { ChromeWebStoreV2 } from '../stores/chrome-web-store-v2';
 
 export async function status(config: InlineConfig): Promise<void> {
   console.log();
@@ -12,12 +9,11 @@ export async function status(config: InlineConfig): Promise<void> {
   if (config.dryRun)
     throw Error('Dry run is not supported when getting item status');
 
-  const resolved = ChromeWebStoreV2Options.parse(
-    resolveChromeV2Options(
-      '...',
-      (config.chrome ?? {}) as ChromeWebStoreV2Options,
-    ),
-  );
+  const { chrome: resolved } = resolveConfig(config);
+  if (!resolved)
+    throw Error('Chrome options are required when getting item status');
+  if (resolved.apiVersion !== 'v2')
+    throw Error('Only v2 API is supported when getting item status');
 
   const store = new ChromeWebStoreV2(resolved, consola.success);
   const res = await store.getStatus();

--- a/src/commands/submit.ts
+++ b/src/commands/submit.ts
@@ -1,6 +1,6 @@
 import { Listr } from 'listr2';
 import { ChromeWebStoreV1_1 } from '../stores/chrome-web-store-v1.1';
-import { InlineConfig, resolveConfig, validateConfig } from '../config';
+import { type InlineConfig, resolveConfig } from '../config';
 import { EdgeAddonStoreV1_1 } from '../stores/edge-addon-store-v1.1';
 import { FirefoxAddonStoreV5 } from '../stores/firefox-addon-store-v5';
 import { OperaAddonsStore } from '../stores/opera-addons-store';
@@ -11,7 +11,8 @@ import { ChromeWebStoreV2 } from '../stores/chrome-web-store-v2';
 export async function submit(config: InlineConfig): Promise<SubmitResults> {
   // Setup
 
-  const internalConfig = validateConfig(resolveConfig(config));
+  const internalConfig = resolveConfig(config);
+  console.log(internalConfig);
 
   console.log();
   consola.info('Publishing Extension');

--- a/src/commands/submit.ts
+++ b/src/commands/submit.ts
@@ -12,7 +12,6 @@ export async function submit(config: InlineConfig): Promise<SubmitResults> {
   // Setup
 
   const internalConfig = resolveConfig(config);
-  console.log(internalConfig);
 
   console.log();
   consola.info('Publishing Extension');

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,302 +1,84 @@
-import { z } from 'zod/v4';
-import { ChromeWebStoreV1_1Options } from './stores/chrome-web-store-v1.1';
-import { EdgeAddonStoreV1_1Options } from './stores/edge-addon-store-v1.1';
-import { FirefoxAddonStoreV5Options } from './stores/firefox-addon-store-v5';
-import type { DeepPartial } from './utils/types';
-import { OperaAddonsStoreOptions } from './stores/opera-addons-store';
-import { ChromeWebStoreV2Options } from './stores/chrome-web-store-v2';
+import { validate } from 'superstruct';
+import { type InlineConfig, ResolvedConfig } from './utils/config-definitions';
 
-/** @deprecated Will be removed October 15th, 2026, when the CWS API v1.1 is shut down. */
-export type AllChromeOptions = {
-  [key in
-    | keyof ChromeWebStoreV1_1Options
-    | keyof ChromeWebStoreV2Options]: key extends keyof ChromeWebStoreV1_1Options
-    ? ChromeWebStoreV1_1Options[key]
-    : key extends keyof ChromeWebStoreV2Options
-      ? ChromeWebStoreV2Options[key]
-      : never;
-};
+export type * from './utils/config-definitions';
+
+/// gen-start:config-resolver
+// prettier-ignore
+/**
+ * Given inline config, read environment variables and apply defaults. Throws an
+ * error if any config is missing.
+ */
+export function resolveConfig(config?: InlineConfig): ResolvedConfig {
+  const raw: Record<string, any> = {}
+
+  // Init store objects
+  const chromeZip  = (config as any)?.chrome?.zip  ?? process.env.CHROME_ZIP
+  const edgeZip    = (config as any)?.edge?.zip    ?? process.env.EDGE_ZIP
+  const firefoxZip = (config as any)?.firefox?.zip ?? process.env.FIREFOX_ZIP
+  const operaZip   = (config as any)?.opera?.zip   ?? process.env.OPERA_ZIP
+
+  if (chromeZip)  raw.chrome  ??= {}
+  if (edgeZip)    raw.edge    ??= {}
+  if (firefoxZip) raw.firefox ??= {}
+  if (operaZip)   raw.opera   ??= {}
+
+  // Set values
+  raw.dryRun                           = (config as any)?.dryRun                            ?? process.env.DRY_RUN
+  if (raw.chrome)  raw.chrome.apiVersion                = (config as any)?.chrome?.apiVersion                ?? process.env.CHROME_API_VERSION
+  if (raw.chrome)  raw.chrome.deployPercentage          = (config as any)?.chrome?.deployPercentage          ?? process.env.CHROME_DEPLOY_PERCENTAGE
+  if (raw.chrome)  raw.chrome.extensionId               = (config as any)?.chrome?.extensionId               ?? process.env.CHROME_EXTENSION_ID
+  if (raw.chrome)  raw.chrome.skipSubmitReview          = (config as any)?.chrome?.skipSubmitReview          ?? process.env.CHROME_SKIP_SUBMIT_REVIEW
+  if (raw.chrome)  raw.chrome.zip                       = (config as any)?.chrome?.zip                       ?? process.env.CHROME_ZIP
+  if (raw.chrome)  raw.chrome.cancelPending             = (config as any)?.chrome?.cancelPending             ?? process.env.CHROME_CANCEL_PENDING
+  if (raw.chrome)  raw.chrome.publisherId               = (config as any)?.chrome?.publisherId               ?? process.env.CHROME_PUBLISHER_ID
+  if (raw.chrome)  raw.chrome.publishType               = (config as any)?.chrome?.publishType               ?? process.env.CHROME_PUBLISH_TYPE
+  if (raw.chrome)  raw.chrome.serviceAccountClientEmail = (config as any)?.chrome?.serviceAccountClientEmail ?? process.env.CHROME_SERVICE_ACCOUNT_CLIENT_EMAIL
+  if (raw.chrome)  raw.chrome.serviceAccountPrivateKey  = (config as any)?.chrome?.serviceAccountPrivateKey  ?? process.env.CHROME_SERVICE_ACCOUNT_PRIVATE_KEY
+  if (raw.chrome)  raw.chrome.skipReview                = (config as any)?.chrome?.skipReview                ?? process.env.CHROME_SKIP_REVIEW
+  if (raw.chrome)  raw.chrome.clientId                  = (config as any)?.chrome?.clientId                  ?? process.env.CHROME_CLIENT_ID
+  if (raw.chrome)  raw.chrome.clientSecret              = (config as any)?.chrome?.clientSecret              ?? process.env.CHROME_CLIENT_SECRET
+  if (raw.chrome)  raw.chrome.publishTarget             = (config as any)?.chrome?.publishTarget             ?? process.env.CHROME_PUBLISH_TARGET
+  if (raw.chrome)  raw.chrome.refreshToken              = (config as any)?.chrome?.refreshToken              ?? process.env.CHROME_REFRESH_TOKEN
+  if (raw.chrome)  raw.chrome.reviewExemption           = (config as any)?.chrome?.reviewExemption           ?? process.env.CHROME_REVIEW_EXEMPTION
+  if (raw.edge)    raw.edge.apiKey                      = (config as any)?.edge?.apiKey                      ?? process.env.EDGE_API_KEY
+  if (raw.edge)    raw.edge.clientId                    = (config as any)?.edge?.clientId                    ?? process.env.EDGE_CLIENT_ID
+  if (raw.edge)    raw.edge.productId                   = (config as any)?.edge?.productId                   ?? process.env.EDGE_PRODUCT_ID
+  if (raw.edge)    raw.edge.skipSubmitReview            = (config as any)?.edge?.skipSubmitReview            ?? process.env.EDGE_SKIP_SUBMIT_REVIEW
+  if (raw.edge)    raw.edge.zip                         = (config as any)?.edge?.zip                         ?? process.env.EDGE_ZIP
+  if (raw.firefox) raw.firefox.channel                  = (config as any)?.firefox?.channel                  ?? process.env.FIREFOX_CHANNEL
+  if (raw.firefox) raw.firefox.compatibility            = (config as any)?.firefox?.compatibility            ?? process.env.FIREFOX_COMPATIBILITY
+  if (raw.firefox) raw.firefox.extensionId              = (config as any)?.firefox?.extensionId              ?? process.env.FIREFOX_EXTENSION_ID
+  if (raw.firefox) raw.firefox.jwtIssuer                = (config as any)?.firefox?.jwtIssuer                ?? process.env.FIREFOX_JWT_ISSUER
+  if (raw.firefox) raw.firefox.jwtSecret                = (config as any)?.firefox?.jwtSecret                ?? process.env.FIREFOX_JWT_SECRET
+  if (raw.firefox) raw.firefox.sourcesZip               = (config as any)?.firefox?.sourcesZip               ?? process.env.FIREFOX_SOURCES_ZIP
+  if (raw.firefox) raw.firefox.zip                      = (config as any)?.firefox?.zip                      ?? process.env.FIREFOX_ZIP
+  if (raw.opera)   raw.opera.packageId                  = (config as any)?.opera?.packageId                  ?? process.env.OPERA_PACKAGE_ID
+  if (raw.opera)   raw.opera.sessionId                  = (config as any)?.opera?.sessionId                  ?? process.env.OPERA_SESSION_ID
+  if (raw.opera)   raw.opera.skipSubmitReview           = (config as any)?.opera?.skipSubmitReview           ?? process.env.OPERA_SKIP_SUBMIT_REVIEW
+  if (raw.opera)   raw.opera.zip                        = (config as any)?.opera?.zip                        ?? process.env.OPERA_ZIP
+
+  return validateConfig(raw);
+}
+/// gen-end:config-resolver
 
 /**
- * Given inline config, read environment variables and apply defaults. Throws an error if any config
- * is missing.
+ * Validate if an object matches `ResolvedConfig`, throwing an error if it is
+ * invalid.
+ *
+ * @internal Generally, you should use `resolveConfig`, which merges env
+ *           variables, applies defaults, and calls this function automatically.
  */
-export function resolveConfig(
-  config: InlineConfig,
-): DeepPartial<InternalConfig> {
-  const dryRun = config.dryRun ?? booleanEnv('DRY_RUN') ?? false;
+export function validateConfig(config: any): ResolvedConfig {
+  const res = validate(config, ResolvedConfig, { coerce: true, mask: true });
+  if (res[1]) return res[1];
 
-  const chromeZip = config.chrome?.zip ?? stringEnv('CHROME_ZIP');
-  const chromeApiVersion =
-    config.chrome?.apiVersion ?? stringEnv('CHROME_API_VERSION');
-  const firefoxZip = config.firefox?.zip ?? stringEnv('FIREFOX_ZIP');
-  const edgeZip = config.edge?.zip ?? stringEnv('EDGE_ZIP');
-  const operaZip = config.opera?.zip ?? stringEnv('OPERA_ZIP');
-
-  return {
-    dryRun,
-    chrome:
-      chromeZip == null
-        ? undefined
-        : chromeApiVersion === 'v2'
-          ? resolveChromeV2Options(
-              chromeZip,
-              config.chrome as Partial<ChromeWebStoreV2Options>,
-            )
-          : buildChromeV1_1Options(
-              chromeZip,
-              config.chrome as Partial<ChromeWebStoreV1_1Options>,
-            ),
-    firefox:
-      firefoxZip == null
-        ? undefined
-        : resolveFirefoxV5Options(
-            firefoxZip,
-            config.firefox as Partial<FirefoxAddonStoreV5Options>,
-          ),
-    edge:
-      edgeZip == null
-        ? undefined
-        : resolveEdgeV1_1Options(
-            edgeZip,
-            config.edge as Partial<EdgeAddonStoreV1_1Options>,
-          ),
-    opera:
-      operaZip == null
-        ? undefined
-        : resolveOperaOptions(
-            operaZip,
-            config.opera as Partial<OperaAddonsStoreOptions>,
-          ),
-  };
-}
-
-function buildChromeV1_1Options(
-  zip: string,
-  chrome: Partial<ChromeWebStoreV1_1Options> | undefined,
-): Partial<ChromeWebStoreV1_1Options> {
-  return {
-    zip,
-    apiVersion: 'v1.1',
-    clientId: chrome?.clientId ?? stringEnv('CHROME_CLIENT_ID'),
-    clientSecret: chrome?.clientSecret ?? stringEnv('CHROME_CLIENT_SECRET'),
-    refreshToken: chrome?.refreshToken ?? stringEnv('CHROME_REFRESH_TOKEN'),
-    extensionId: chrome?.extensionId ?? stringEnv('CHROME_EXTENSION_ID'),
-    publishTarget:
-      chrome?.publishTarget ?? stringEnv('CHROME_PUBLISH_TARGET') ?? 'default',
-    reviewExemption:
-      chrome?.reviewExemption ?? booleanEnv('CHROME_REVIEW_EXEMPTION') ?? false,
-    skipSubmitReview:
-      chrome?.skipSubmitReview ??
-      booleanEnv('CHROME_SKIP_SUBMIT_REVIEW') ??
-      false,
-    deployPercentage:
-      chrome?.deployPercentage ?? numberEnv('CHROME_DEPLOY_PERCENTAGE'),
-  };
-}
-
-export function resolveChromeV2Options(
-  zip: string,
-  chrome: Partial<ChromeWebStoreV2Options> | undefined,
-): Partial<ChromeWebStoreV2Options> {
-  return {
-    zip,
-    apiVersion: 'v2',
-    extensionId: chrome?.extensionId ?? stringEnv('CHROME_EXTENSION_ID'),
-    publisherId: chrome?.publisherId ?? stringEnv('CHROME_PUBLISHER_ID'),
-    serviceAccountClientEmail:
-      chrome?.serviceAccountClientEmail ??
-      stringEnv('CHROME_SERVICE_ACCOUNT_CLIENT_EMAIL'),
-    serviceAccountPrivateKey:
-      chrome?.serviceAccountPrivateKey ??
-      stringEnv('CHROME_SERVICE_ACCOUNT_PRIVATE_KEY'),
-    publishType: chrome?.publishType ?? stringEnv('CHROME_PUBLISH_TYPE'),
-    deployPercentage:
-      chrome?.deployPercentage ?? numberEnv('CHROME_DEPLOY_PERCENTAGE'),
-    skipReview: chrome?.skipReview ?? booleanEnv('CHROME_SKIP_REVIEW'),
-    skipSubmitReview:
-      chrome?.skipSubmitReview ??
-      booleanEnv('CHROME_SKIP_SUBMIT_REVIEW') ??
-      false,
-    cancelPending:
-      chrome?.cancelPending ?? booleanEnv('CHROME_CANCEL_PENDING') ?? false,
-  };
-}
-
-function resolveFirefoxV5Options(
-  zip: string,
-  firefox: Partial<FirefoxAddonStoreV5Options> | undefined,
-): Partial<FirefoxAddonStoreV5Options> {
-  return {
-    zip,
-    sourcesZip: firefox?.sourcesZip ?? stringEnv('FIREFOX_SOURCES_ZIP'),
-    extensionId: firefox?.extensionId ?? stringEnv('FIREFOX_EXTENSION_ID'),
-    jwtIssuer: firefox?.jwtIssuer ?? stringEnv('FIREFOX_JWT_ISSUER'),
-    jwtSecret: firefox?.jwtSecret ?? stringEnv('FIREFOX_JWT_SECRET'),
-    channel: firefox?.channel ?? stringEnv('FIREFOX_CHANNEL') ?? 'listed',
-    compatibility:
-      firefox?.compatibility ??
-      (stringEnv('FIREFOX_COMPATIBILITY')?.split(',') as any),
-  };
-}
-
-function resolveEdgeV1_1Options(
-  zip: string,
-  edge: Partial<EdgeAddonStoreV1_1Options> | undefined,
-): Partial<EdgeAddonStoreV1_1Options> {
-  return {
-    zip,
-    productId: edge?.productId ?? stringEnv('EDGE_PRODUCT_ID'),
-    clientId: edge?.clientId ?? stringEnv('EDGE_CLIENT_ID'),
-    apiKey: edge?.apiKey ?? stringEnv('EDGE_API_KEY'),
-    skipSubmitReview:
-      edge?.skipSubmitReview ?? booleanEnv('EDGE_SKIP_SUBMIT_REVIEW') ?? false,
-  };
-}
-
-function resolveOperaOptions(
-  zip: string,
-  opera: Partial<OperaAddonsStoreOptions> | undefined,
-): Partial<OperaAddonsStoreOptions> {
-  return {
-    zip,
-    packageId: opera?.packageId ?? intEnv('OPERA_PACKAGE_ID'),
-    sessionId: opera?.sessionId ?? stringEnv('OPERA_SESSION_ID'),
-    skipSubmitReview:
-      opera?.skipSubmitReview ??
-      booleanEnv('OPERA_SKIP_SUBMIT_REVIEW') ??
-      false,
-  };
-}
-
-function toScreamingSnakeCase(str: string): string {
-  return str
-    .replace(/([A-Z])/g, '_$1')
-    .replace(/-/g, '_')
-    .toUpperCase();
-}
-
-export function validateConfig(config: any): InternalConfig {
-  const result = InternalConfig.safeParse(config);
-
-  if (!result.success) {
-    throw Error(
-      'Missing required config: ' +
-        result.error.issues
-          .map(i => i.path.map(j => toScreamingSnakeCase(String(j))).join('_'))
-          .join(', '),
-      { cause: result.error },
-    );
-  }
-  return result.data;
-}
-
-function booleanEnv(name: keyof CustomEnv): boolean | undefined {
-  return !process.env[name] ? undefined : process.env[name] === 'true';
-}
-
-function stringEnv<T extends string = string>(
-  name: keyof CustomEnv,
-): T | undefined {
-  return !process.env[name] ? undefined : (process.env[name] as T);
-}
-
-function numberEnv(name: keyof CustomEnv): number | undefined {
-  return !process.env[name] ? undefined : parseFloat(process.env[name]!);
-}
-
-function intEnv(name: keyof CustomEnv): number | undefined {
-  return !process.env[name] ? undefined : parseInt(process.env[name]!);
-}
-
-export const InlineConfig = z.object({
-  /**
-   * When true, just check authentication, don't upload any zip files or submit any updates.
-   */
-  dryRun: z.boolean().optional(),
-  /**
-   * Options for publishing to chrome.
-   */
-  chrome: z
-    .union([
-      ChromeWebStoreV1_1Options.partial(),
-      ChromeWebStoreV2Options.partial(),
-    ])
-    .optional(),
-  /**
-   * Options for publishing to Firefox.
-   */
-  firefox: FirefoxAddonStoreV5Options.partial().optional(),
-  /**
-   * Options for publishing to Edge.
-   */
-  edge: EdgeAddonStoreV1_1Options.partial().optional(),
-  /**
-   * Options for publishing to Opera
-   */
-  opera: OperaAddonsStoreOptions.partial().optional(),
-});
-export type InlineConfig = z.infer<typeof InlineConfig>;
-
-export const InternalConfig = z.object({
-  dryRun: z.boolean(),
-  chrome: z
-    .discriminatedUnion('apiVersion', [
-      ChromeWebStoreV1_1Options,
-      ChromeWebStoreV2Options,
-    ])
-    .optional(),
-  firefox: FirefoxAddonStoreV5Options.optional(),
-  edge: EdgeAddonStoreV1_1Options.optional(),
-  opera: OperaAddonsStoreOptions.optional(),
-});
-export type InternalConfig = z.infer<typeof InternalConfig>;
-
-export interface CustomEnv {
-  DRY_RUN: string | undefined;
-
-  // CWS
-  CHROME_EXTENSION_ID: string | undefined;
-  CHROME_DEPLOY_PERCENTAGE: string | undefined;
-  CHROME_SKIP_SUBMIT_REVIEW: string | undefined;
-  CHROME_ZIP: string | undefined;
-  CHROME_API_VERSION: 'v1.1' | 'v2' | undefined;
-  // CWS v1.1
-  CHROME_CLIENT_ID: string | undefined;
-  CHROME_CLIENT_SECRET: string | undefined;
-  CHROME_PUBLISH_TARGET: string | undefined;
-  CHROME_REFRESH_TOKEN: string | undefined;
-  CHROME_REVIEW_EXEMPTION: string | undefined;
-  // CWS v2
-  CHROME_PUBLISHER_ID: string | undefined;
-  CHROME_SERVICE_ACCOUNT_CLIENT_EMAIL: string | undefined;
-  CHROME_SERVICE_ACCOUNT_PRIVATE_KEY: string | undefined;
-  CHROME_PUBLISH_TYPE: string | undefined;
-  CHROME_SKIP_REVIEW: string | undefined;
-  CHROME_CANCEL_PENDING: string | undefined;
-
-  FIREFOX_ZIP: string | undefined;
-  FIREFOX_SOURCES_ZIP: string | undefined;
-  FIREFOX_EXTENSION_ID: string | undefined;
-  FIREFOX_JWT_ISSUER: string | undefined;
-  FIREFOX_JWT_SECRET: string | undefined;
-  FIREFOX_CHANNEL: string | undefined;
-  FIREFOX_COMPATIBILITY: string | undefined;
-
-  EDGE_ZIP: string | undefined;
-  EDGE_PRODUCT_ID: string | undefined;
-  EDGE_CLIENT_ID: string | undefined;
-  EDGE_API_KEY: string | undefined;
-  EDGE_SKIP_SUBMIT_REVIEW: string | undefined;
-
-  OPERA_ZIP: string | undefined;
-  OPERA_PACKAGE_ID: string | undefined;
-  OPERA_SESSION_ID: string | undefined;
-  OPERA_SKIP_SUBMIT_REVIEW: string | undefined;
-}
-
-declare global {
-  namespace NodeJS {
-    interface ProcessEnv extends CustomEnv {}
-  }
+  throw Error(
+    [
+      'Invalid config:',
+      ...res[0]
+        .failures()
+        .map(err => `  - \`${err.path.join('.')}\`: ${err.message}`),
+    ].join('\n'),
+  );
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import { validate } from 'superstruct';
-import { type InlineConfig, ResolvedConfig } from './utils/config-definitions';
+import { type InlineConfig, ResolvedConfig } from './utils/config-schema';
 
 export type {
   AllChromeOptions,
@@ -13,7 +13,7 @@ export type {
   InternalConfig,
   OperaAddonsStoreOptions,
   ResolvedConfig,
-} from './utils/config-definitions';
+} from './utils/config-schema';
 
 /// gen-start:config-resolver
 // prettier-ignore

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,16 @@
 import { validate } from 'superstruct';
 import { type InlineConfig, ResolvedConfig } from './utils/config-definitions';
 
-export type * from './utils/config-definitions';
+export type {
+  ChromeWebStoreV2Options,
+  EdgeAddonStoreOptions,
+  EdgeAddonStoreV1_1Options,
+  FirefoxAddonStoreOptions,
+  FirefoxAddonStoreV5Options,
+  OperaAddonsStoreOptions,
+  ResolvedConfig,
+  InlineConfig,
+} from './utils/config-definitions';
 
 /// gen-start:config-resolver
 // prettier-ignore

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,14 +2,17 @@ import { validate } from 'superstruct';
 import { type InlineConfig, ResolvedConfig } from './utils/config-definitions';
 
 export type {
+  AllChromeOptions,
+  ChromeWebStoreV1_1Options,
   ChromeWebStoreV2Options,
   EdgeAddonStoreOptions,
   EdgeAddonStoreV1_1Options,
   FirefoxAddonStoreOptions,
   FirefoxAddonStoreV5Options,
+  InlineConfig,
+  InternalConfig,
   OperaAddonsStoreOptions,
   ResolvedConfig,
-  InlineConfig,
 } from './utils/config-definitions';
 
 /// gen-start:config-resolver
@@ -22,10 +25,10 @@ export function resolveConfig(config?: InlineConfig): ResolvedConfig {
   const raw: Record<string, any> = {}
 
   // Init store objects
-  const chromeZip  = (config as any)?.chrome?.zip  ?? process.env.CHROME_ZIP 
-  const edgeZip    = (config as any)?.edge?.zip    ?? process.env.EDGE_ZIP   
+  const chromeZip  = (config as any)?.chrome?.zip  ?? process.env.CHROME_ZIP
+  const edgeZip    = (config as any)?.edge?.zip    ?? process.env.EDGE_ZIP
   const firefoxZip = (config as any)?.firefox?.zip ?? process.env.FIREFOX_ZIP
-  const operaZip   = (config as any)?.opera?.zip   ?? process.env.OPERA_ZIP  
+  const operaZip   = (config as any)?.opera?.zip   ?? process.env.OPERA_ZIP
 
   if (chromeZip)  raw.chrome  ??= {}
   if (edgeZip)    raw.edge    ??= {}
@@ -33,39 +36,39 @@ export function resolveConfig(config?: InlineConfig): ResolvedConfig {
   if (operaZip)   raw.opera   ??= {}
 
   // Set values
-  raw.dryRun                           = (config as any)?.dryRun                            ?? process.env.DRY_RUN                         
-  if (raw.chrome)  raw.chrome.apiVersion                = (config as any)?.chrome?.apiVersion                ?? process.env.CHROME_API_VERSION              
-  if (raw.chrome)  raw.chrome.deployPercentage          = (config as any)?.chrome?.deployPercentage          ?? process.env.CHROME_DEPLOY_PERCENTAGE        
-  if (raw.chrome)  raw.chrome.extensionId               = (config as any)?.chrome?.extensionId               ?? process.env.CHROME_EXTENSION_ID             
-  if (raw.chrome)  raw.chrome.skipSubmitReview          = (config as any)?.chrome?.skipSubmitReview          ?? process.env.CHROME_SKIP_SUBMIT_REVIEW       
-  if (raw.chrome)  raw.chrome.zip                       = (config as any)?.chrome?.zip                       ?? process.env.CHROME_ZIP                      
-  if (raw.chrome)  raw.chrome.cancelPending             = (config as any)?.chrome?.cancelPending             ?? process.env.CHROME_CANCEL_PENDING           
-  if (raw.chrome)  raw.chrome.publisherId               = (config as any)?.chrome?.publisherId               ?? process.env.CHROME_PUBLISHER_ID             
-  if (raw.chrome)  raw.chrome.publishType               = (config as any)?.chrome?.publishType               ?? process.env.CHROME_PUBLISH_TYPE             
+  raw.dryRun                           = (config as any)?.dryRun                            ?? process.env.DRY_RUN
+  if (raw.chrome)  raw.chrome.apiVersion                = (config as any)?.chrome?.apiVersion                ?? process.env.CHROME_API_VERSION
+  if (raw.chrome)  raw.chrome.deployPercentage          = (config as any)?.chrome?.deployPercentage          ?? process.env.CHROME_DEPLOY_PERCENTAGE
+  if (raw.chrome)  raw.chrome.extensionId               = (config as any)?.chrome?.extensionId               ?? process.env.CHROME_EXTENSION_ID
+  if (raw.chrome)  raw.chrome.skipSubmitReview          = (config as any)?.chrome?.skipSubmitReview          ?? process.env.CHROME_SKIP_SUBMIT_REVIEW
+  if (raw.chrome)  raw.chrome.zip                       = (config as any)?.chrome?.zip                       ?? process.env.CHROME_ZIP
+  if (raw.chrome)  raw.chrome.cancelPending             = (config as any)?.chrome?.cancelPending             ?? process.env.CHROME_CANCEL_PENDING
+  if (raw.chrome)  raw.chrome.publisherId               = (config as any)?.chrome?.publisherId               ?? process.env.CHROME_PUBLISHER_ID
+  if (raw.chrome)  raw.chrome.publishType               = (config as any)?.chrome?.publishType               ?? process.env.CHROME_PUBLISH_TYPE
   if (raw.chrome)  raw.chrome.serviceAccountClientEmail = (config as any)?.chrome?.serviceAccountClientEmail ?? process.env.CHROME_SERVICE_ACCOUNT_CLIENT_EMAIL
   if (raw.chrome)  raw.chrome.serviceAccountPrivateKey  = (config as any)?.chrome?.serviceAccountPrivateKey  ?? process.env.CHROME_SERVICE_ACCOUNT_PRIVATE_KEY
-  if (raw.chrome)  raw.chrome.skipReview                = (config as any)?.chrome?.skipReview                ?? process.env.CHROME_SKIP_REVIEW              
-  if (raw.chrome)  raw.chrome.clientId                  = (config as any)?.chrome?.clientId                  ?? process.env.CHROME_CLIENT_ID                
-  if (raw.chrome)  raw.chrome.clientSecret              = (config as any)?.chrome?.clientSecret              ?? process.env.CHROME_CLIENT_SECRET            
-  if (raw.chrome)  raw.chrome.publishTarget             = (config as any)?.chrome?.publishTarget             ?? process.env.CHROME_PUBLISH_TARGET           
-  if (raw.chrome)  raw.chrome.refreshToken              = (config as any)?.chrome?.refreshToken              ?? process.env.CHROME_REFRESH_TOKEN            
-  if (raw.chrome)  raw.chrome.reviewExemption           = (config as any)?.chrome?.reviewExemption           ?? process.env.CHROME_REVIEW_EXEMPTION         
-  if (raw.edge)    raw.edge.apiKey                      = (config as any)?.edge?.apiKey                      ?? process.env.EDGE_API_KEY                    
-  if (raw.edge)    raw.edge.clientId                    = (config as any)?.edge?.clientId                    ?? process.env.EDGE_CLIENT_ID                  
-  if (raw.edge)    raw.edge.productId                   = (config as any)?.edge?.productId                   ?? process.env.EDGE_PRODUCT_ID                 
-  if (raw.edge)    raw.edge.skipSubmitReview            = (config as any)?.edge?.skipSubmitReview            ?? process.env.EDGE_SKIP_SUBMIT_REVIEW         
-  if (raw.edge)    raw.edge.zip                         = (config as any)?.edge?.zip                         ?? process.env.EDGE_ZIP                        
-  if (raw.firefox) raw.firefox.channel                  = (config as any)?.firefox?.channel                  ?? process.env.FIREFOX_CHANNEL                 
-  if (raw.firefox) raw.firefox.compatibility            = (config as any)?.firefox?.compatibility            ?? process.env.FIREFOX_COMPATIBILITY           
-  if (raw.firefox) raw.firefox.extensionId              = (config as any)?.firefox?.extensionId              ?? process.env.FIREFOX_EXTENSION_ID            
-  if (raw.firefox) raw.firefox.jwtIssuer                = (config as any)?.firefox?.jwtIssuer                ?? process.env.FIREFOX_JWT_ISSUER              
-  if (raw.firefox) raw.firefox.jwtSecret                = (config as any)?.firefox?.jwtSecret                ?? process.env.FIREFOX_JWT_SECRET              
-  if (raw.firefox) raw.firefox.sourcesZip               = (config as any)?.firefox?.sourcesZip               ?? process.env.FIREFOX_SOURCES_ZIP             
-  if (raw.firefox) raw.firefox.zip                      = (config as any)?.firefox?.zip                      ?? process.env.FIREFOX_ZIP                     
-  if (raw.opera)   raw.opera.packageId                  = (config as any)?.opera?.packageId                  ?? process.env.OPERA_PACKAGE_ID                
-  if (raw.opera)   raw.opera.sessionId                  = (config as any)?.opera?.sessionId                  ?? process.env.OPERA_SESSION_ID                
-  if (raw.opera)   raw.opera.skipSubmitReview           = (config as any)?.opera?.skipSubmitReview           ?? process.env.OPERA_SKIP_SUBMIT_REVIEW        
-  if (raw.opera)   raw.opera.zip                        = (config as any)?.opera?.zip                        ?? process.env.OPERA_ZIP                       
+  if (raw.chrome)  raw.chrome.skipReview                = (config as any)?.chrome?.skipReview                ?? process.env.CHROME_SKIP_REVIEW
+  if (raw.chrome)  raw.chrome.clientId                  = (config as any)?.chrome?.clientId                  ?? process.env.CHROME_CLIENT_ID
+  if (raw.chrome)  raw.chrome.clientSecret              = (config as any)?.chrome?.clientSecret              ?? process.env.CHROME_CLIENT_SECRET
+  if (raw.chrome)  raw.chrome.publishTarget             = (config as any)?.chrome?.publishTarget             ?? process.env.CHROME_PUBLISH_TARGET
+  if (raw.chrome)  raw.chrome.refreshToken              = (config as any)?.chrome?.refreshToken              ?? process.env.CHROME_REFRESH_TOKEN
+  if (raw.chrome)  raw.chrome.reviewExemption           = (config as any)?.chrome?.reviewExemption           ?? process.env.CHROME_REVIEW_EXEMPTION
+  if (raw.edge)    raw.edge.apiKey                      = (config as any)?.edge?.apiKey                      ?? process.env.EDGE_API_KEY
+  if (raw.edge)    raw.edge.clientId                    = (config as any)?.edge?.clientId                    ?? process.env.EDGE_CLIENT_ID
+  if (raw.edge)    raw.edge.productId                   = (config as any)?.edge?.productId                   ?? process.env.EDGE_PRODUCT_ID
+  if (raw.edge)    raw.edge.skipSubmitReview            = (config as any)?.edge?.skipSubmitReview            ?? process.env.EDGE_SKIP_SUBMIT_REVIEW
+  if (raw.edge)    raw.edge.zip                         = (config as any)?.edge?.zip                         ?? process.env.EDGE_ZIP
+  if (raw.firefox) raw.firefox.channel                  = (config as any)?.firefox?.channel                  ?? process.env.FIREFOX_CHANNEL
+  if (raw.firefox) raw.firefox.compatibility            = (config as any)?.firefox?.compatibility            ?? process.env.FIREFOX_COMPATIBILITY
+  if (raw.firefox) raw.firefox.extensionId              = (config as any)?.firefox?.extensionId              ?? process.env.FIREFOX_EXTENSION_ID
+  if (raw.firefox) raw.firefox.jwtIssuer                = (config as any)?.firefox?.jwtIssuer                ?? process.env.FIREFOX_JWT_ISSUER
+  if (raw.firefox) raw.firefox.jwtSecret                = (config as any)?.firefox?.jwtSecret                ?? process.env.FIREFOX_JWT_SECRET
+  if (raw.firefox) raw.firefox.sourcesZip               = (config as any)?.firefox?.sourcesZip               ?? process.env.FIREFOX_SOURCES_ZIP
+  if (raw.firefox) raw.firefox.zip                      = (config as any)?.firefox?.zip                      ?? process.env.FIREFOX_ZIP
+  if (raw.opera)   raw.opera.packageId                  = (config as any)?.opera?.packageId                  ?? process.env.OPERA_PACKAGE_ID
+  if (raw.opera)   raw.opera.sessionId                  = (config as any)?.opera?.sessionId                  ?? process.env.OPERA_SESSION_ID
+  if (raw.opera)   raw.opera.skipSubmitReview           = (config as any)?.opera?.skipSubmitReview           ?? process.env.OPERA_SKIP_SUBMIT_REVIEW
+  if (raw.opera)   raw.opera.zip                        = (config as any)?.opera?.zip                        ?? process.env.OPERA_ZIP
 
   return validateConfig(raw);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,10 +13,10 @@ export function resolveConfig(config?: InlineConfig): ResolvedConfig {
   const raw: Record<string, any> = {}
 
   // Init store objects
-  const chromeZip  = (config as any)?.chrome?.zip  ?? process.env.CHROME_ZIP
-  const edgeZip    = (config as any)?.edge?.zip    ?? process.env.EDGE_ZIP
+  const chromeZip  = (config as any)?.chrome?.zip  ?? process.env.CHROME_ZIP 
+  const edgeZip    = (config as any)?.edge?.zip    ?? process.env.EDGE_ZIP   
   const firefoxZip = (config as any)?.firefox?.zip ?? process.env.FIREFOX_ZIP
-  const operaZip   = (config as any)?.opera?.zip   ?? process.env.OPERA_ZIP
+  const operaZip   = (config as any)?.opera?.zip   ?? process.env.OPERA_ZIP  
 
   if (chromeZip)  raw.chrome  ??= {}
   if (edgeZip)    raw.edge    ??= {}
@@ -24,39 +24,39 @@ export function resolveConfig(config?: InlineConfig): ResolvedConfig {
   if (operaZip)   raw.opera   ??= {}
 
   // Set values
-  raw.dryRun                           = (config as any)?.dryRun                            ?? process.env.DRY_RUN
-  if (raw.chrome)  raw.chrome.apiVersion                = (config as any)?.chrome?.apiVersion                ?? process.env.CHROME_API_VERSION
-  if (raw.chrome)  raw.chrome.deployPercentage          = (config as any)?.chrome?.deployPercentage          ?? process.env.CHROME_DEPLOY_PERCENTAGE
-  if (raw.chrome)  raw.chrome.extensionId               = (config as any)?.chrome?.extensionId               ?? process.env.CHROME_EXTENSION_ID
-  if (raw.chrome)  raw.chrome.skipSubmitReview          = (config as any)?.chrome?.skipSubmitReview          ?? process.env.CHROME_SKIP_SUBMIT_REVIEW
-  if (raw.chrome)  raw.chrome.zip                       = (config as any)?.chrome?.zip                       ?? process.env.CHROME_ZIP
-  if (raw.chrome)  raw.chrome.cancelPending             = (config as any)?.chrome?.cancelPending             ?? process.env.CHROME_CANCEL_PENDING
-  if (raw.chrome)  raw.chrome.publisherId               = (config as any)?.chrome?.publisherId               ?? process.env.CHROME_PUBLISHER_ID
-  if (raw.chrome)  raw.chrome.publishType               = (config as any)?.chrome?.publishType               ?? process.env.CHROME_PUBLISH_TYPE
+  raw.dryRun                           = (config as any)?.dryRun                            ?? process.env.DRY_RUN                         
+  if (raw.chrome)  raw.chrome.apiVersion                = (config as any)?.chrome?.apiVersion                ?? process.env.CHROME_API_VERSION              
+  if (raw.chrome)  raw.chrome.deployPercentage          = (config as any)?.chrome?.deployPercentage          ?? process.env.CHROME_DEPLOY_PERCENTAGE        
+  if (raw.chrome)  raw.chrome.extensionId               = (config as any)?.chrome?.extensionId               ?? process.env.CHROME_EXTENSION_ID             
+  if (raw.chrome)  raw.chrome.skipSubmitReview          = (config as any)?.chrome?.skipSubmitReview          ?? process.env.CHROME_SKIP_SUBMIT_REVIEW       
+  if (raw.chrome)  raw.chrome.zip                       = (config as any)?.chrome?.zip                       ?? process.env.CHROME_ZIP                      
+  if (raw.chrome)  raw.chrome.cancelPending             = (config as any)?.chrome?.cancelPending             ?? process.env.CHROME_CANCEL_PENDING           
+  if (raw.chrome)  raw.chrome.publisherId               = (config as any)?.chrome?.publisherId               ?? process.env.CHROME_PUBLISHER_ID             
+  if (raw.chrome)  raw.chrome.publishType               = (config as any)?.chrome?.publishType               ?? process.env.CHROME_PUBLISH_TYPE             
   if (raw.chrome)  raw.chrome.serviceAccountClientEmail = (config as any)?.chrome?.serviceAccountClientEmail ?? process.env.CHROME_SERVICE_ACCOUNT_CLIENT_EMAIL
   if (raw.chrome)  raw.chrome.serviceAccountPrivateKey  = (config as any)?.chrome?.serviceAccountPrivateKey  ?? process.env.CHROME_SERVICE_ACCOUNT_PRIVATE_KEY
-  if (raw.chrome)  raw.chrome.skipReview                = (config as any)?.chrome?.skipReview                ?? process.env.CHROME_SKIP_REVIEW
-  if (raw.chrome)  raw.chrome.clientId                  = (config as any)?.chrome?.clientId                  ?? process.env.CHROME_CLIENT_ID
-  if (raw.chrome)  raw.chrome.clientSecret              = (config as any)?.chrome?.clientSecret              ?? process.env.CHROME_CLIENT_SECRET
-  if (raw.chrome)  raw.chrome.publishTarget             = (config as any)?.chrome?.publishTarget             ?? process.env.CHROME_PUBLISH_TARGET
-  if (raw.chrome)  raw.chrome.refreshToken              = (config as any)?.chrome?.refreshToken              ?? process.env.CHROME_REFRESH_TOKEN
-  if (raw.chrome)  raw.chrome.reviewExemption           = (config as any)?.chrome?.reviewExemption           ?? process.env.CHROME_REVIEW_EXEMPTION
-  if (raw.edge)    raw.edge.apiKey                      = (config as any)?.edge?.apiKey                      ?? process.env.EDGE_API_KEY
-  if (raw.edge)    raw.edge.clientId                    = (config as any)?.edge?.clientId                    ?? process.env.EDGE_CLIENT_ID
-  if (raw.edge)    raw.edge.productId                   = (config as any)?.edge?.productId                   ?? process.env.EDGE_PRODUCT_ID
-  if (raw.edge)    raw.edge.skipSubmitReview            = (config as any)?.edge?.skipSubmitReview            ?? process.env.EDGE_SKIP_SUBMIT_REVIEW
-  if (raw.edge)    raw.edge.zip                         = (config as any)?.edge?.zip                         ?? process.env.EDGE_ZIP
-  if (raw.firefox) raw.firefox.channel                  = (config as any)?.firefox?.channel                  ?? process.env.FIREFOX_CHANNEL
-  if (raw.firefox) raw.firefox.compatibility            = (config as any)?.firefox?.compatibility            ?? process.env.FIREFOX_COMPATIBILITY
-  if (raw.firefox) raw.firefox.extensionId              = (config as any)?.firefox?.extensionId              ?? process.env.FIREFOX_EXTENSION_ID
-  if (raw.firefox) raw.firefox.jwtIssuer                = (config as any)?.firefox?.jwtIssuer                ?? process.env.FIREFOX_JWT_ISSUER
-  if (raw.firefox) raw.firefox.jwtSecret                = (config as any)?.firefox?.jwtSecret                ?? process.env.FIREFOX_JWT_SECRET
-  if (raw.firefox) raw.firefox.sourcesZip               = (config as any)?.firefox?.sourcesZip               ?? process.env.FIREFOX_SOURCES_ZIP
-  if (raw.firefox) raw.firefox.zip                      = (config as any)?.firefox?.zip                      ?? process.env.FIREFOX_ZIP
-  if (raw.opera)   raw.opera.packageId                  = (config as any)?.opera?.packageId                  ?? process.env.OPERA_PACKAGE_ID
-  if (raw.opera)   raw.opera.sessionId                  = (config as any)?.opera?.sessionId                  ?? process.env.OPERA_SESSION_ID
-  if (raw.opera)   raw.opera.skipSubmitReview           = (config as any)?.opera?.skipSubmitReview           ?? process.env.OPERA_SKIP_SUBMIT_REVIEW
-  if (raw.opera)   raw.opera.zip                        = (config as any)?.opera?.zip                        ?? process.env.OPERA_ZIP
+  if (raw.chrome)  raw.chrome.skipReview                = (config as any)?.chrome?.skipReview                ?? process.env.CHROME_SKIP_REVIEW              
+  if (raw.chrome)  raw.chrome.clientId                  = (config as any)?.chrome?.clientId                  ?? process.env.CHROME_CLIENT_ID                
+  if (raw.chrome)  raw.chrome.clientSecret              = (config as any)?.chrome?.clientSecret              ?? process.env.CHROME_CLIENT_SECRET            
+  if (raw.chrome)  raw.chrome.publishTarget             = (config as any)?.chrome?.publishTarget             ?? process.env.CHROME_PUBLISH_TARGET           
+  if (raw.chrome)  raw.chrome.refreshToken              = (config as any)?.chrome?.refreshToken              ?? process.env.CHROME_REFRESH_TOKEN            
+  if (raw.chrome)  raw.chrome.reviewExemption           = (config as any)?.chrome?.reviewExemption           ?? process.env.CHROME_REVIEW_EXEMPTION         
+  if (raw.edge)    raw.edge.apiKey                      = (config as any)?.edge?.apiKey                      ?? process.env.EDGE_API_KEY                    
+  if (raw.edge)    raw.edge.clientId                    = (config as any)?.edge?.clientId                    ?? process.env.EDGE_CLIENT_ID                  
+  if (raw.edge)    raw.edge.productId                   = (config as any)?.edge?.productId                   ?? process.env.EDGE_PRODUCT_ID                 
+  if (raw.edge)    raw.edge.skipSubmitReview            = (config as any)?.edge?.skipSubmitReview            ?? process.env.EDGE_SKIP_SUBMIT_REVIEW         
+  if (raw.edge)    raw.edge.zip                         = (config as any)?.edge?.zip                         ?? process.env.EDGE_ZIP                        
+  if (raw.firefox) raw.firefox.channel                  = (config as any)?.firefox?.channel                  ?? process.env.FIREFOX_CHANNEL                 
+  if (raw.firefox) raw.firefox.compatibility            = (config as any)?.firefox?.compatibility            ?? process.env.FIREFOX_COMPATIBILITY           
+  if (raw.firefox) raw.firefox.extensionId              = (config as any)?.firefox?.extensionId              ?? process.env.FIREFOX_EXTENSION_ID            
+  if (raw.firefox) raw.firefox.jwtIssuer                = (config as any)?.firefox?.jwtIssuer                ?? process.env.FIREFOX_JWT_ISSUER              
+  if (raw.firefox) raw.firefox.jwtSecret                = (config as any)?.firefox?.jwtSecret                ?? process.env.FIREFOX_JWT_SECRET              
+  if (raw.firefox) raw.firefox.sourcesZip               = (config as any)?.firefox?.sourcesZip               ?? process.env.FIREFOX_SOURCES_ZIP             
+  if (raw.firefox) raw.firefox.zip                      = (config as any)?.firefox?.zip                      ?? process.env.FIREFOX_ZIP                     
+  if (raw.opera)   raw.opera.packageId                  = (config as any)?.opera?.packageId                  ?? process.env.OPERA_PACKAGE_ID                
+  if (raw.opera)   raw.opera.sessionId                  = (config as any)?.opera?.sessionId                  ?? process.env.OPERA_SESSION_ID                
+  if (raw.opera)   raw.opera.skipSubmitReview           = (config as any)?.opera?.skipSubmitReview           ?? process.env.OPERA_SKIP_SUBMIT_REVIEW        
+  if (raw.opera)   raw.opera.zip                        = (config as any)?.opera?.zip                        ?? process.env.OPERA_ZIP                       
 
   return validateConfig(raw);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export * from './commands/submit';
 export * from './commands/init';
-export { InlineConfig } from './config';
+export * from './config';
 
 export * from './stores/firefox-addon-store-v5';
 export * from './stores/edge-addon-store-v1.1';

--- a/src/stores/chrome-web-store-v1.1.ts
+++ b/src/stores/chrome-web-store-v1.1.ts
@@ -1,29 +1,11 @@
 import type { Store } from './store';
-import { z } from 'zod/v4';
 import { ensureZipExists } from '../utils/fs';
 import { createHttpClient, type HttpClient } from '../utils/http-client';
 import { CwsApiV1_1 } from '../apis/cws-api-v1.1.gen';
 import { FetchError } from '../utils/errors';
 import { createReadStream } from 'node:fs';
 import consola from 'consola';
-
-/** @deprecated Will be removed October 15th, 2026, when the CWS API v1.1 is shut down. */
-export const ChromeWebStoreV1_1Options = z.object({
-  apiVersion: z.literal('v1.1').optional(),
-  zip: z.string().min(1),
-  extensionId: z.string().min(1).trim(),
-  clientId: z.string().min(1).trim(),
-  clientSecret: z.string().min(1).trim(),
-  refreshToken: z.string().min(1).trim(),
-  publishTarget: z.enum(['default', 'trustedTesters']).default('default'),
-  deployPercentage: z.int().min(1).max(100).optional(),
-  reviewExemption: z.boolean().default(false),
-  skipSubmitReview: z.boolean().default(false),
-});
-/** @deprecated Will be removed October 15th, 2026, when the CWS API v1.1 is shut down. */
-export type ChromeWebStoreV1_1Options = z.infer<
-  typeof ChromeWebStoreV1_1Options
->;
+import type { ChromeWebStoreV1_1Options } from '../utils/config-definitions';
 
 /** @deprecated Will be removed October 15th, 2026, when the CWS API v1.1 is shut down. */
 export interface CwsTokenDetails {
@@ -145,6 +127,4 @@ export class ChromeWebStoreUploadStateError extends Error {
 export {
   /** @deprecated Use ChromeWebStoreV1_1 instead. */
   ChromeWebStoreV1_1 as ChromeWebStore,
-  /** @deprecated Use ChromeWebStoreV1_1Options instead. */
-  ChromeWebStoreV1_1Options as ChromeWebStoreOptions,
 };

--- a/src/stores/chrome-web-store-v1.1.ts
+++ b/src/stores/chrome-web-store-v1.1.ts
@@ -5,7 +5,7 @@ import { CwsApiV1_1 } from '../apis/cws-api-v1.1.gen';
 import { FetchError } from '../utils/errors';
 import { createReadStream } from 'node:fs';
 import consola from 'consola';
-import type { ChromeWebStoreV1_1Options } from '../utils/config-definitions';
+import type { ChromeWebStoreV1_1Options } from '../utils/config-schema';
 
 /** @deprecated Will be removed October 15th, 2026, when the CWS API v1.1 is shut down. */
 export interface CwsTokenDetails {

--- a/src/stores/chrome-web-store-v2.ts
+++ b/src/stores/chrome-web-store-v2.ts
@@ -1,5 +1,4 @@
 import type { Store } from './store';
-import { z } from 'zod/v4';
 import { ensureZipExists } from '../utils/fs';
 import { createHttpClient, type HttpClient } from '../utils/http-client';
 import { CwsApiV2 } from '../apis/cws-api-v2.gen';
@@ -7,27 +6,7 @@ import { createGcpServiceAccountJwt } from '../utils/google-auth';
 import { createReadStream } from 'node:fs';
 import { ChromeWebStoreUploadStateError } from './chrome-web-store-v1.1';
 import consola from 'consola';
-
-type PublishType = NonNullable<CwsApiV2.PublishItemRequest['publishType']>;
-
-export const ChromeWebStoreV2Options = z.object({
-  apiVersion: z.literal('v2'),
-  zip: z.string().min(1),
-  extensionId: z.string().min(1).trim(),
-  publisherId: z.string().min(1).trim(),
-  serviceAccountClientEmail: z.string().min(1).trim(),
-  serviceAccountPrivateKey: z.string().min(1),
-  publishType: z
-    .enum<
-      PublishType[]
-    >(['PUBLISH_TYPE_UNSPECIFIED', 'DEFAULT_PUBLISH', 'STAGED_PUBLISH'])
-    .optional(),
-  deployPercentage: z.int().min(1).max(100).optional(),
-  skipReview: z.boolean().default(false),
-  skipSubmitReview: z.boolean().default(false),
-  cancelPending: z.boolean().default(false),
-});
-export type ChromeWebStoreV2Options = z.infer<typeof ChromeWebStoreV2Options>;
+import type { ChromeWebStoreV2Options } from '../utils/config-definitions';
 
 export interface ServiceAccountTokenResponse {
   access_token: string;

--- a/src/stores/chrome-web-store-v2.ts
+++ b/src/stores/chrome-web-store-v2.ts
@@ -6,7 +6,7 @@ import { createGcpServiceAccountJwt } from '../utils/google-auth';
 import { createReadStream } from 'node:fs';
 import { ChromeWebStoreUploadStateError } from './chrome-web-store-v1.1';
 import consola from 'consola';
-import type { ChromeWebStoreV2Options } from '../utils/config-definitions';
+import type { ChromeWebStoreV2Options } from '../utils/config-schema';
 
 export interface ServiceAccountTokenResponse {
   access_token: string;

--- a/src/stores/edge-addon-store-v1.1.ts
+++ b/src/stores/edge-addon-store-v1.1.ts
@@ -77,6 +77,4 @@ export class EdgeAddonStoreV1_1 implements Store {
 export {
   /** @deprecated Use EdgeAddonStoreV1_1 instead. */
   EdgeAddonStoreV1_1 as EdgeAddonStore,
-  /** @deprecated Use EdgeAddonStoreV1_1Options instead. */
-  EdgeAddonStoreV1_1Options as EdgeAddonStoreOptions,
 };

--- a/src/stores/edge-addon-store-v1.1.ts
+++ b/src/stores/edge-addon-store-v1.1.ts
@@ -1,22 +1,10 @@
 import { EdgeApiV1_1 } from '../apis/edge-api-v1.1';
 import type { Store } from './store';
-import { z } from 'zod/v4';
 import { ensureZipExists } from '../utils/fs';
 import { createHttpClient, type HttpClient } from '../utils/http-client';
 import { pollUntil } from '../utils/polling';
 import { createReadStream } from 'node:fs';
-
-export const EdgeAddonStoreV1_1Options = z.object({
-  zip: z.string().min(1),
-  productId: z.string().min(1).trim(),
-  clientId: z.string().min(1).trim(),
-  skipSubmitReview: z.boolean().default(false),
-  apiKey: z.string().min(1).trim(),
-});
-
-export type EdgeAddonStoreV1_1Options = z.infer<
-  typeof EdgeAddonStoreV1_1Options
->;
+import type { EdgeAddonStoreV1_1Options } from '../config';
 
 export class EdgeAddonStoreV1_1 implements Store {
   private client: HttpClient<EdgeApiV1_1.Endpoints>;

--- a/src/stores/firefox-addon-store-v5.ts
+++ b/src/stores/firefox-addon-store-v5.ts
@@ -1,6 +1,5 @@
 import { plural } from '../utils/plural';
 import type { Store } from './store';
-import { z } from 'zod/v4';
 import { ensureZipExists } from '../utils/fs';
 import { createHttpClient, type HttpClient } from '../utils/http-client';
 import { FirefoxApiV5 } from '../apis/firefox-api-v5';
@@ -10,19 +9,7 @@ import { FormData } from 'formdata-node';
 import { fileFromPath } from 'formdata-node/file-from-path';
 import { FormDataEncoder } from 'form-data-encoder';
 import { Readable } from 'node:stream';
-
-export const FirefoxAddonStoreV5Options = z.object({
-  zip: z.string().min(1),
-  sourcesZip: z.string().min(1).optional(),
-  extensionId: z.string().min(1).trim(),
-  jwtIssuer: z.string().min(1).trim(),
-  jwtSecret: z.string().min(1).trim(),
-  channel: z.enum(['listed', 'unlisted']).default('listed'),
-  compatibility: z.enum(['firefox', 'android']).array().optional(),
-});
-export type FirefoxAddonStoreV5Options = z.infer<
-  typeof FirefoxAddonStoreV5Options
->;
+import type { FirefoxAddonStoreV5Options } from '../config';
 
 export class FirefoxAddonStoreV5 implements Store {
   private client: HttpClient<FirefoxApiV5.Endpoints>;
@@ -165,6 +152,4 @@ export class FirefoxAddonStoreV5 implements Store {
 export {
   /** @deprecated Use FirefoxAddonStoreV5 instead. */
   FirefoxAddonStoreV5 as FirefoxAddonStore,
-  /** @deprecated Use FirefoxAddonStoreV5Options instead. */
-  FirefoxAddonStoreV5Options as FirefoxAddonStoreOptions,
 };

--- a/src/stores/opera-addons-store.ts
+++ b/src/stores/opera-addons-store.ts
@@ -1,16 +1,7 @@
-import { z } from 'zod/v4';
 import type { Store } from './store';
 import { ensureZipExists } from '../utils/fs';
 import { OperaAddonsApi } from '../apis/opera-api';
-
-export const OperaAddonsStoreOptions = z.object({
-  zip: z.string().min(1),
-  packageId: z.number().min(1),
-  sessionId: z.string().min(1).trim(),
-  skipSubmitReview: z.boolean().default(false),
-});
-
-export type OperaAddonsStoreOptions = z.infer<typeof OperaAddonsStoreOptions>;
+import type { OperaAddonsStoreOptions } from '../config';
 
 export class OperaAddonsStore implements Store {
   private api: OperaAddonsApi;

--- a/src/utils/config-definitions.ts
+++ b/src/utils/config-definitions.ts
@@ -1,0 +1,301 @@
+import {
+  object,
+  optional,
+  literal,
+  Struct,
+  nonempty,
+  string,
+  number,
+  min,
+  max,
+  enums,
+  boolean,
+  coerce,
+  union,
+  type Infer,
+  dynamic,
+  array,
+  trimmed,
+  defaulted,
+} from 'superstruct';
+import type { DeepPartial } from './types';
+
+export interface MetaStruct<T> extends Struct<T> {
+  '~meta': {
+    description: string;
+    path: string;
+    note?: string;
+  };
+}
+
+function meta<T>(
+  struct: Struct<T>,
+  options: { path: string; description: string; note?: string },
+): MetaStruct<T> {
+  const s = struct as MetaStruct<T>;
+  s['~meta'] = {
+    path: options.path,
+    description: options.description,
+    note: options.note,
+  };
+  return s;
+}
+
+export function isMetaStruct<T>(struct: Struct<T>): struct is MetaStruct<T> {
+  return (struct as any)['~meta'];
+}
+
+const stringbool = coerce(
+  boolean(),
+  union([literal('true'), literal('false'), boolean()]),
+  v => {
+    if (v === 'true') return true;
+    if (v === 'false') return false;
+    return v;
+  },
+);
+
+const coercedNumber = coerce(number(), union([string(), number()]), v => {
+  if (typeof v === 'string') return parseFloat(v);
+  return v;
+});
+
+const ChromeWebStoreSharedOptionsShape = {
+  zip: meta(nonempty(string()), {
+    path: 'chrome.zip',
+    description: 'Path to extension zip to upload',
+  }),
+  deployPercentage: meta(optional(min(max(coercedNumber, 100), 0)), {
+    path: 'chrome.deployPercentage',
+    description: 'An integer from 0-100',
+  }),
+  extensionId: meta(nonempty(trimmed(string())), {
+    path: 'chrome.extensionId',
+    description: 'The ID of the extension to be submitted',
+  }),
+  skipSubmitReview: meta(defaulted(stringbool, false), {
+    path: 'chrome.skipSubmitReview',
+    description:
+      "Just upload the extension zip, don't submit it for review or publish it",
+  }),
+};
+
+/** @deprecated Will be removed October 15th, 2026, when the CWS API v1.1 is shut down. */
+export const ChromeWebStoreV1_1Options = object({
+  apiVersion: meta(optional(literal('v1.1')), {
+    path: 'chrome.apiVersion',
+    description:
+      'The API version to use for the Chrome Web Store: "v1.1" or "v2" (default: v1.1)',
+  }),
+  ...ChromeWebStoreSharedOptionsShape,
+  clientId: meta(nonempty(trimmed(string())), {
+    path: 'chrome.clientId',
+    note: 'Deprecated: API v1.1 only',
+    description:
+      'Client ID used for authorizing requests to the Chrome Web Store',
+  }),
+  clientSecret: meta(nonempty(trimmed(string())), {
+    path: 'chrome.clientSecret',
+    note: 'Deprecated: API v1.1 only',
+    description:
+      'Client secret used for authorizing requests to the Chrome Web Store',
+  }),
+  refreshToken: meta(nonempty(trimmed(string())), {
+    path: 'chrome.refreshToken',
+    note: 'Deprecated: API v1.1 only',
+    description:
+      'Refresh token used for authorizing requests to the Chrome Web Store',
+  }),
+  publishTarget: meta(optional(enums(['default', 'trustedTesters'])), {
+    path: 'chrome.publishTarget',
+    note: 'Deprecated: API v1.1 only',
+    description: 'Group to publish to, "default" or "trustedTesters"',
+  }),
+  reviewExemption: meta(optional(stringbool), {
+    path: 'chrome.reviewExemption',
+    note: 'Deprecated: API v1.1 only',
+    description: 'Submit update using expedited review process',
+  }),
+});
+
+/** @deprecated Will be removed October 15th, 2026, when the CWS API v1.1 is shut down. */
+export type ChromeWebStoreV1_1Options = Infer<typeof ChromeWebStoreV1_1Options>;
+
+export const ChromeWebStoreV2Options = object({
+  apiVersion: meta(literal('v2'), {
+    path: 'chrome.apiVersion',
+    description:
+      'The API version to use for the Chrome Web Store: "v1.1" or "v2" (default: v1.1)',
+  }),
+  ...ChromeWebStoreSharedOptionsShape,
+  publisherId: meta(nonempty(trimmed(string())), {
+    path: 'chrome.publisherId',
+    note: 'API v2 only',
+    description: 'Publisher ID who owns the extension',
+  }),
+  serviceAccountClientEmail: meta(nonempty(trimmed(string())), {
+    path: 'chrome.serviceAccountClientEmail',
+    note: 'API v2 only',
+    description:
+      'Client email of the service account used for authorizing requests to the Chrome Web Store',
+  }),
+  serviceAccountPrivateKey: meta(nonempty(trimmed(string())), {
+    path: 'chrome.serviceAccountPrivateKey',
+    note: 'API v2 only',
+    description:
+      'Private key of the service account used for authorizing requests to the Chrome Web Store',
+  }),
+  publishType: meta(
+    optional(
+      enums(['PUBLISH_TYPE_UNSPECIFIED', 'DEFAULT_PUBLISH', 'STAGED_PUBLISH']),
+    ),
+    {
+      path: 'chrome.publishType',
+      note: 'API v2 only',
+      description:
+        'Set to "STAGED_PUBLISH" to not publish the extension immediately after submission',
+    },
+  ),
+  skipReview: meta(optional(stringbool), {
+    path: 'chrome.skipReview',
+    note: 'API v2 only',
+    description:
+      'Some updates, like ad-blocker rule updates, can skip the review process and be published immediately after submission',
+  }),
+  cancelPending: meta(defaulted(stringbool, false), {
+    path: 'chrome.cancelPending',
+    note: 'API v2 only',
+    description: 'Cancel any pending review before submitting the new version',
+  }),
+});
+
+export type ChromeWebStoreV2Options = Infer<typeof ChromeWebStoreV2Options>;
+
+/** @deprecated Will be removed October 15th, 2026, when the CWS API v1.1 is shut down. */
+export type AllChromeOptions = {
+  [key in
+    | keyof ChromeWebStoreV1_1Options
+    | keyof ChromeWebStoreV2Options]: key extends keyof ChromeWebStoreV1_1Options
+    ? ChromeWebStoreV1_1Options[key]
+    : key extends keyof ChromeWebStoreV2Options
+      ? ChromeWebStoreV2Options[key]
+      : never;
+};
+
+export const FirefoxAddonStoreV5Options = object({
+  zip: meta(nonempty(string()), {
+    path: 'firefox.zip',
+    description: 'Path to extension zip to upload',
+  }),
+  sourcesZip: meta(optional(nonempty(string())), {
+    path: 'firefox.sourcesZip',
+    description: 'Path to sources zip to upload',
+  }),
+  extensionId: meta(nonempty(trimmed(string())), {
+    path: 'firefox.extensionId',
+    description: 'The ID of the extension to be submitted',
+  }),
+  jwtIssuer: meta(nonempty(trimmed(string())), {
+    path: 'firefox.jwtIssuer',
+    description: 'Issuer used for authorizing requests to Addon Store APIs',
+  }),
+  jwtSecret: meta(nonempty(trimmed(string())), {
+    path: 'firefox.jwtSecret',
+    description: 'Secret used for authorizing requests to Addon Store APIs',
+  }),
+  channel: meta(defaulted(enums(['listed', 'unlisted']), 'listed'), {
+    path: 'firefox.channel',
+    description: 'The channel to publish to, "listed" or "unlisted"',
+  }),
+  compatibility: meta(optional(array(enums(['firefox', 'android']))), {
+    path: 'firefox.compatibility',
+    description:
+      'Comma-separated list of compatible applications, e.g. "firefox,android"',
+  }),
+});
+
+export type FirefoxAddonStoreV5Options = Infer<
+  typeof FirefoxAddonStoreV5Options
+>;
+
+export const EdgeAddonStoreV1_1Options = object({
+  zip: meta(nonempty(string()), {
+    path: 'edge.zip',
+    description: 'Path to extension zip to upload',
+  }),
+  productId: meta(nonempty(trimmed(string())), {
+    path: 'edge.productId',
+    description: 'Product ID listed on the developer dashboard',
+  }),
+  clientId: meta(nonempty(trimmed(string())), {
+    path: 'edge.clientId',
+    description:
+      'Client ID used for authorizing requests to Microsofts addon API',
+  }),
+  apiKey: meta(nonempty(trimmed(string())), {
+    path: 'edge.apiKey',
+    description:
+      'API key used for authorizing requests to Microsofts addon API v1.1',
+  }),
+  skipSubmitReview: meta(defaulted(stringbool, false), {
+    path: 'edge.skipSubmitReview',
+    description:
+      "Just upload the extension zip, don't submit it for review or publish it",
+  }),
+});
+
+export type EdgeAddonStoreV1_1Options = Infer<typeof EdgeAddonStoreV1_1Options>;
+
+export const OperaAddonsStoreOptions = object({
+  zip: meta(nonempty(string()), {
+    path: 'opera.zip',
+    description: 'Path to extension zip to upload',
+  }),
+  packageId: meta(coercedNumber, {
+    path: 'opera.packageId',
+    description:
+      'Package ID listed in the package developer URL: https://addons.opera.com/developer/package/<packageId>',
+  }),
+  sessionId: meta(nonempty(trimmed(string())), {
+    path: 'opera.sessionId',
+    description: 'Session ID used for authorizing requests to Opera Addons API',
+  }),
+  skipSubmitReview: meta(defaulted(stringbool, false), {
+    path: 'opera.skipSubmitReview',
+    description:
+      "Just upload the extension zip, don't submit it for review or publish it",
+  }),
+});
+
+export type OperaAddonsStoreOptions = Infer<typeof OperaAddonsStoreOptions>;
+
+export const ResolvedConfig = object({
+  dryRun: meta(defaulted(stringbool, false), {
+    path: 'dryRun',
+    description:
+      "Check authentication, but don't upload the zip or submit for review",
+  }),
+  chrome: optional(
+    dynamic<ChromeWebStoreV1_1Options | ChromeWebStoreV2Options>(v =>
+      (v as any)?.apiVersion === 'v2'
+        ? (ChromeWebStoreV2Options as any)
+        : (ChromeWebStoreV1_1Options as any),
+    ),
+  ),
+  firefox: optional(FirefoxAddonStoreV5Options),
+  edge: optional(EdgeAddonStoreV1_1Options),
+  opera: optional(OperaAddonsStoreOptions),
+});
+export {
+  /** @deprecated Use FirefoxAddonStoreV5Options instead. */
+  FirefoxAddonStoreV5Options as FirefoxAddonStoreOptions,
+};
+
+export type ResolvedConfig = Infer<typeof ResolvedConfig>;
+
+/** @deprecated Renamed to `ResolvedConfig` */
+export const InternalConfig = ResolvedConfig;
+/** @deprecated Renamed to `ResolvedConfig` */
+export type InternalConfig = ResolvedConfig;
+
+export type InlineConfig = DeepPartial<ResolvedConfig>;

--- a/src/utils/config-definitions.ts
+++ b/src/utils/config-definitions.ts
@@ -286,9 +286,12 @@ export const ResolvedConfig = object({
   edge: optional(EdgeAddonStoreV1_1Options),
   opera: optional(OperaAddonsStoreOptions),
 });
+
 export {
   /** @deprecated Use FirefoxAddonStoreV5Options instead. */
   FirefoxAddonStoreV5Options as FirefoxAddonStoreOptions,
+  /** @deprecated Use EdgeAddonStoreV1_1Options instead. */
+  EdgeAddonStoreV1_1Options as EdgeAddonStoreOptions,
 };
 
 export type ResolvedConfig = Infer<typeof ResolvedConfig>;

--- a/src/utils/config-definitions.ts
+++ b/src/utils/config-definitions.ts
@@ -85,7 +85,7 @@ export const ChromeWebStoreV1_1Options = object({
   apiVersion: meta(optional(literal('v1.1')), {
     path: 'chrome.apiVersion',
     description:
-      'The API version to use for the Chrome Web Store: "v1.1" or "v2" (default: v1.1)',
+      'The API version to use for the Chrome Web Store: "v1.1" or "v2"',
   }),
   ...ChromeWebStoreSharedOptionsShape,
   clientId: meta(nonempty(trimmed(string())), {
@@ -125,7 +125,7 @@ export const ChromeWebStoreV2Options = object({
   apiVersion: meta(literal('v2'), {
     path: 'chrome.apiVersion',
     description:
-      'The API version to use for the Chrome Web Store: "v1.1" or "v2" (default: v1.1)',
+      'The API version to use for the Chrome Web Store: "v1.1" or "v2"',
   }),
   ...ChromeWebStoreSharedOptionsShape,
   publisherId: meta(nonempty(trimmed(string())), {

--- a/src/utils/config-schema.ts
+++ b/src/utils/config-schema.ts
@@ -60,6 +60,9 @@ const coercedNumber = coerce(number(), union([string(), number()]), v => {
   return v;
 });
 
+const commaArray = <T>(struct: Struct<T>) =>
+  coerce(array(struct), string(), v => v.split(','));
+
 const ChromeWebStoreSharedOptionsShape = {
   zip: meta(nonempty(string()), {
     path: 'chrome.zip',
@@ -207,10 +210,10 @@ export const FirefoxAddonStoreV5Options = object({
     path: 'firefox.channel',
     description: 'The channel to publish to, "listed" or "unlisted"',
   }),
-  compatibility: meta(optional(array(enums(['firefox', 'android']))), {
+  compatibility: meta(optional(commaArray(enums(['firefox', 'android']))), {
     path: 'firefox.compatibility',
     description:
-      'Comma-separated list of compatible applications, e.g. "firefox,android"',
+      'Comma-separated list of compatible applications, e.g. "firefox,android" - "firefox" for compatibility with Firefox desktop apps, "android" for Firefox Android apps',
   }),
 });
 

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -1,0 +1,92 @@
+/// gen-start:config-env
+export interface CustomEnv {
+  /** Check authentication, but don't upload the zip or submit for review */
+  DRY_RUN: string | undefined;
+  /** The API version to use for the Chrome Web Store: "v1.1" or "v2" (default: v1.1) */
+  CHROME_API_VERSION: string | undefined;
+  /** An integer from 0-100 */
+  CHROME_DEPLOY_PERCENTAGE: string | undefined;
+  /** The ID of the extension to be submitted */
+  CHROME_EXTENSION_ID: string | undefined;
+  /** Just upload the extension zip, don't submit it for review or publish it */
+  CHROME_SKIP_SUBMIT_REVIEW: string | undefined;
+  /** Path to extension zip to upload */
+  CHROME_ZIP: string | undefined;
+  /** [API v2 only] Cancel any pending review before submitting the new version */
+  CHROME_CANCEL_PENDING: string | undefined;
+  /** [API v2 only] Publisher ID who owns the extension */
+  CHROME_PUBLISHER_ID: string | undefined;
+  /** [API v2 only] Set to "STAGED_PUBLISH" to not publish the extension immediately after submission */
+  CHROME_PUBLISH_TYPE: string | undefined;
+  /** [API v2 only] Client email of the service account used for authorizing requests to the Chrome Web Store */
+  CHROME_SERVICE_ACCOUNT_CLIENT_EMAIL: string | undefined;
+  /** [API v2 only] Private key of the service account used for authorizing requests to the Chrome Web Store */
+  CHROME_SERVICE_ACCOUNT_PRIVATE_KEY: string | undefined;
+  /** [API v2 only] Some updates, like ad-blocker rule updates, can skip the review process and be published immediately after submission */
+  CHROME_SKIP_REVIEW: string | undefined;
+  /** [Deprecated: API v1.1 only] Client ID used for authorizing requests to the Chrome Web Store */
+  CHROME_CLIENT_ID: string | undefined;
+  /** [Deprecated: API v1.1 only] Client secret used for authorizing requests to the Chrome Web Store */
+  CHROME_CLIENT_SECRET: string | undefined;
+  /** [Deprecated: API v1.1 only] Group to publish to, "default" or "trustedTesters" */
+  CHROME_PUBLISH_TARGET: string | undefined;
+  /** [Deprecated: API v1.1 only] Refresh token used for authorizing requests to the Chrome Web Store */
+  CHROME_REFRESH_TOKEN: string | undefined;
+  /** [Deprecated: API v1.1 only] Submit update using expedited review process */
+  CHROME_REVIEW_EXEMPTION: string | undefined;
+  /** API key used for authorizing requests to Microsofts addon API v1.1 */
+  EDGE_API_KEY: string | undefined;
+  /** Client ID used for authorizing requests to Microsofts addon API */
+  EDGE_CLIENT_ID: string | undefined;
+  /** Product ID listed on the developer dashboard */
+  EDGE_PRODUCT_ID: string | undefined;
+  /** Just upload the extension zip, don't submit it for review or publish it */
+  EDGE_SKIP_SUBMIT_REVIEW: string | undefined;
+  /** Path to extension zip to upload */
+  EDGE_ZIP: string | undefined;
+  /** The channel to publish to, "listed" or "unlisted" */
+  FIREFOX_CHANNEL: string | undefined;
+  /** Comma-separated list of compatible applications, e.g. "firefox,android" */
+  FIREFOX_COMPATIBILITY: string | undefined;
+  /** The ID of the extension to be submitted */
+  FIREFOX_EXTENSION_ID: string | undefined;
+  /** Issuer used for authorizing requests to Addon Store APIs */
+  FIREFOX_JWT_ISSUER: string | undefined;
+  /** Secret used for authorizing requests to Addon Store APIs */
+  FIREFOX_JWT_SECRET: string | undefined;
+  /** Path to sources zip to upload */
+  FIREFOX_SOURCES_ZIP: string | undefined;
+  /** Path to extension zip to upload */
+  FIREFOX_ZIP: string | undefined;
+  /** Package ID listed in the package developer URL: https://addons.opera.com/developer/package/<packageId> */
+  OPERA_PACKAGE_ID: string | undefined;
+  /** Session ID used for authorizing requests to Opera Addons API */
+  OPERA_SESSION_ID: string | undefined;
+  /** Just upload the extension zip, don't submit it for review or publish it */
+  OPERA_SKIP_SUBMIT_REVIEW: string | undefined;
+  /** Path to extension zip to upload */
+  OPERA_ZIP: string | undefined;
+}
+/// gen-end:config-env
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv extends CustomEnv {}
+  }
+}
+
+export function booleanEnv(name: keyof CustomEnv): boolean | undefined {
+  return !process.env[name] ? undefined : process.env[name] === 'true';
+}
+
+export function stringEnv(name: keyof CustomEnv): string | undefined {
+  return !process.env[name] ? undefined : process.env[name];
+}
+
+export function stringArrayEnv(name: keyof CustomEnv): string[] | undefined {
+  return stringEnv(name)?.split(',');
+}
+
+export function numberEnv(name: keyof CustomEnv): number | undefined {
+  return !process.env[name] ? undefined : parseFloat(process.env[name]!);
+}

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -74,19 +74,3 @@ declare global {
     interface ProcessEnv extends CustomEnv {}
   }
 }
-
-export function booleanEnv(name: keyof CustomEnv): boolean | undefined {
-  return !process.env[name] ? undefined : process.env[name] === 'true';
-}
-
-export function stringEnv(name: keyof CustomEnv): string | undefined {
-  return !process.env[name] ? undefined : process.env[name];
-}
-
-export function stringArrayEnv(name: keyof CustomEnv): string[] | undefined {
-  return stringEnv(name)?.split(',');
-}
-
-export function numberEnv(name: keyof CustomEnv): number | undefined {
-  return !process.env[name] ? undefined : parseFloat(process.env[name]!);
-}

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -46,7 +46,7 @@ export interface CustomEnv {
   EDGE_ZIP: string | undefined;
   /** The channel to publish to, "listed" or "unlisted" */
   FIREFOX_CHANNEL: string | undefined;
-  /** Comma-separated list of compatible applications, e.g. "firefox,android" */
+  /** Comma-separated list of compatible applications, e.g. "firefox,android" - "firefox" for compatibility with Firefox desktop apps, "android" for Firefox Android apps */
   FIREFOX_COMPATIBILITY: string | undefined;
   /** The ID of the extension to be submitted */
   FIREFOX_EXTENSION_ID: string | undefined;

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -2,7 +2,7 @@
 export interface CustomEnv {
   /** Check authentication, but don't upload the zip or submit for review */
   DRY_RUN: string | undefined;
-  /** The API version to use for the Chrome Web Store: "v1.1" or "v2" (default: v1.1) */
+  /** The API version to use for the Chrome Web Store: "v1.1" or "v2" */
   CHROME_API_VERSION: string | undefined;
   /** An integer from 0-100 */
   CHROME_DEPLOY_PERCENTAGE: string | undefined;


### PR DESCRIPTION
## Overview

1. Replace `zod` ([4.6 MB / 1 package](https://pkg-size.dev/zod)) with `superstruct` ([182KB / 1 package](https://pkg-size.dev/superstruct)), apart of #76.
   - We're down to [2.3MB / 34 packages](https://pkg-size.dev/https:%2F%2Fpkg.pr.new%2Faklinker1%2Fpublish-browser-extension@77)
   - [I did try rolling my own validation](https://github.com/aklinker1/publish-browser-extension/commit/50b4594f5f29f0bd54f7af973b4bcd134ae9e0a9), but it was taking too long (I use more features than I thought), so it wasn't as tiny as I'd have liked.
   - For now, I'm inlining `superstruct`, so it's not a dependency, and unused functions are tree-shaken out of the bundled package
3. Define config in a single place, and generate all mapper functions, CLI options, and documentation

Here's the new docs for the config reference: https://github.com/aklinker1/publish-browser-extension/blob/config-refactor/docs/config-reference.md

## Manual Testing

See E2E tests and new unit tests.
