### PR TITLE
refactor: Refactor opera API client

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,23 +36,27 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup
-      - run: |
-          bun ./scripts/dev.mjs chrome
-          bun ./scripts/dev.mjs firefox
-          bun ./scripts/dev.mjs edge
+      - run: bun dev:all
         env:
+          # Chrome
           CHROME_EXTENSION_ID: ${{ secrets.TEST_CHROME_EXTENSION_ID }}
           CHROME_CLIENT_ID: ${{ secrets.TEST_CHROME_CLIENT_ID }}
           CHROME_CLIENT_SECRET: ${{ secrets.TEST_CHROME_CLIENT_SECRET }}
           CHROME_REFRESH_TOKEN: ${{ secrets.TEST_CHROME_REFRESH_TOKEN }}
           CHROME_SKIP_SUBMIT_REVIEW: 'true'
           CHROME_PUBLISH_TARGET: trustedTesters
+          # Firefox
           FIREFOX_EXTENSION_ID: ${{ secrets.TEST_FIREFOX_EXTENSION_ID }}
           FIREFOX_JWT_ISSUER: ${{ secrets.TEST_FIREFOX_JWT_ISSUER }}
           FIREFOX_JWT_SECRET: ${{ secrets.TEST_FIREFOX_JWT_SECRET }}
           FIREFOX_CHANNEL: unlisted
           FIREFOX_COMPATIBILITY: firefox,android
+          # Edge
           EDGE_PRODUCT_ID: ${{ secrets.TEST_EDGE_PRODUCT_ID }}
           EDGE_CLIENT_ID: ${{ secrets.TEST_EDGE_CLIENT_ID }}
           EDGE_API_KEY: ${{ secrets.TEST_EDGE_API_KEY }}
           EDGE_SKIP_SUBMIT_REVIEW: 'true'
+          # Opera
+          OPERA_PACKAGE_ID: ${{ secrets.TEST_OPERA_PACKAGE_ID }}
+          OPERA_SESSION_ID: ${{ secrets.TEST_OPERA_SESSION_ID }}
+          OPERA_SKIP_SUBMIT_REVIEW: 'true'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,9 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup
-      - run: |
-          node --version
-          bun dev:opera
+      - run: bun dev:all
         env:
           # Chrome
           CHROME_EXTENSION_ID: ${{ secrets.TEST_CHROME_EXTENSION_ID }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,7 +36,9 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup
-      - run: bun dev:all
+      - run: |
+          node --version
+          bun dev:opera
         env:
           # Chrome
           CHROME_EXTENSION_ID: ${{ secrets.TEST_CHROME_EXTENSION_ID }}

--- a/src/apis/opera-api.ts
+++ b/src/apis/opera-api.ts
@@ -1,10 +1,4 @@
-import { fetch } from '../utils/fetch';
-import { FormData } from 'formdata-node';
-import { FormDataEncoder } from 'form-data-encoder';
 import { Readable } from 'node:stream';
-import fs from 'node:fs';
-import path from 'node:path';
-import { Blob } from 'node:buffer';
 import type {
   OperaAddonApiError,
   OperaAddonDetails,
@@ -16,231 +10,105 @@ import type { DeepPartial } from '../utils/types';
 // API guessed from : https://addons-static.operacdn.com/static/CACHE/js/catalog.6c1172c19572.js
 // And by looking at the HTTP requests while using the website
 
-export interface OperaAddonsApiOptions {
-  sessionId: string;
-}
+export namespace OperaApi {
+  export const BASE_URL = 'https://addons.opera.com';
 
-export class OperaAddonsApi {
-  private readonly operaApiUrl = 'https://addons.opera.com/api';
-  private readonly csrfToken: string;
-  private readonly sessionId: string;
-
-  constructor(options: OperaAddonsApiOptions) {
-    this.sessionId = options.sessionId;
-    this.csrfToken = this.generateCSRFToken();
-  }
-
-  private uploadFileEndpoint = () =>
-    `${this.operaApiUrl}/file-upload/` as const;
-
-  private uploadValidateEndpoint = (packageId: number) =>
-    `${this.operaApiUrl}/developer/package-versions/?package_id=${packageId}` as const;
-
-  private addonDetailsEndpoint = (packageId: number) =>
-    `${this.operaApiUrl}/developer/packages/${packageId}/` as const;
-
-  // Trailing slash is required - Opera's backend (Django) has APPEND_SLASH=True, so a request
-  // without it gets 301-redirected, and fetch will follow the redirect as a GET, causing a 405.
-  private submitVersionEndpoint = (packageId: number, version: string) =>
-    `${this.operaApiUrl}/developer/package-versions/${packageId}-${version}/submit_for_moderation/` as const;
-
-  private addonVersionDetailsEndpoint = (packageId: number, version: string) =>
-    `${this.operaApiUrl}/developer/package-versions/${packageId}-${version}/` as const;
-
-  /**
-   * Get the detailed information about an Opera Addon
-   */
-  public async getAddonDetails(params: {
-    packageId: number;
-  }): Promise<OperaAddonDetails | OperaAddonApiError> {
-    const endpoint = this.addonDetailsEndpoint(params.packageId);
-
-    return await fetch(endpoint, {
-      method: 'GET',
-      headers: {
-        accept: 'application/json; version=1.0',
-        cookie: `INGRESSCOOKIE_API; sessionid=${this.sessionId};`,
-      },
-    });
-  }
-
-  public async getAddonVersionDetails(params: {
-    packageId: number;
-    version: string;
-  }): Promise<OperaAddonVersionDetails | OperaAddonApiError> {
-    const endpoint = this.addonVersionDetailsEndpoint(
-      params.packageId,
-      params.version,
-    );
-
-    return await fetch(endpoint, {
-      method: 'GET',
-      headers: {
-        accept: 'application/json; version=1.0',
-        cookie: `INGRESSCOOKIE_API; sessionid=${this.sessionId};`,
-      },
-    });
-  }
-
-  public async updateAddonVersionDetails(params: {
-    packageId: number;
-    version: string;
-    details: DeepPartial<OperaAddonVersionDetails>;
-  }): Promise<OperaAddonVersionDetails | OperaAddonApiError> {
-    const endpoint = this.addonVersionDetailsEndpoint(
-      params.packageId,
-      params.version,
-    );
-
-    return await fetch(endpoint, {
-      method: 'PATCH',
-      headers: {
-        accept: 'application/json; version=1.0',
-        'x-csrftoken': this.csrfToken,
-        cookie: `INGRESSCOOKIE_API; sessionid=${this.sessionId}; csrftoken=${this.csrfToken};`,
-        Referer: `https://addons.opera.com/developer/package/${params.packageId}/version/${params.version}`,
-      },
-      body: params.details,
-    });
-  }
-
-  /**
-   * Upload a new package version for an Opera Addon
-   */
-  public async uploadFile(params: { packageId: number; file: string }) {
-    const endpoint = this.uploadFileEndpoint();
-    const fileInfo = await this.fileInfo(params.file);
-
-    const chunkSize = 1024 * 1024;
-    const totalChunks = Math.ceil(fileInfo.size / chunkSize);
-
-    const identifier = this.generateFileIdentifier(
-      fileInfo.size,
-      fileInfo.name,
-    );
-
-    const stream = fs.createReadStream(params.file, {
-      highWaterMark: chunkSize,
-    });
-
-    let chunkNumber = 1;
-
-    for await (const chunk of stream) {
-      const form = new FormData();
-
-      form.append('file', new Blob([chunk]), fileInfo.name);
-
-      form.append('flowChunkNumber', String(chunkNumber));
-      form.append('flowChunkSize', String(chunkSize));
-      form.append('flowCurrentChunkSize', String(chunk.length));
-      form.append('flowTotalSize', String(fileInfo.size));
-      form.append('flowIdentifier', identifier);
-      form.append('flowFilename', fileInfo.name);
-      form.append('flowRelativePath', fileInfo.name);
-      form.append('flowTotalChunks', String(totalChunks));
-
-      const encoder = new FormDataEncoder(form);
-
-      const res = await fetch.raw(endpoint, {
-        method: 'POST',
-        headers: {
-          ...encoder.headers,
-          'x-csrftoken': this.csrfToken,
-          Referer: `https://addons.opera.com/developer/package/${params.packageId}/`,
-          cookie: `INGRESSCOOKIE_API; sessionid=${this.sessionId}; csrftoken=${this.csrfToken};`,
-        },
-        body: Readable.from(encoder),
-      });
-
-      if (res.status < 200 || res.status >= 300) {
-        throw new Error(`Chunk ${chunkNumber} upload failed (${res.status})`);
-      }
-
-      chunkNumber++;
-    }
-
-    return {
-      fileId: identifier,
-      fileName: fileInfo.name,
-    } as const;
-  }
-
-  /**
-   * Bind an uploaded file to an addon package
-   */
-  public async validateFileUpload(params: {
-    packageId: number;
+  export interface FileUploadResponse {
     fileId: `${number}-${string}`;
     fileName: string;
-    lastVersion: string;
-  }): Promise<OperaAddonFileValidationResponse | OperaAddonApiError> {
-    const endpoint = this.uploadValidateEndpoint(params.packageId);
-
-    return fetch(endpoint, {
-      method: 'POST',
-      headers: {
-        'x-csrftoken': this.csrfToken,
-        Referer: `https://addons.opera.com/developer/package/${params.packageId}/`,
-        accept: 'application/json; version=1.0',
-        cookie: `INGRESSCOOKIE_API; sessionid=${this.sessionId}; csrftoken=${this.csrfToken};`,
-      },
-      body: {
-        file_id: params.fileId,
-        file_name: params.fileName,
-        metadata_from: params.lastVersion,
-      },
-      // There might be some delay between the upload file request finishing and
-      // the file being actually available for validation, so the request might
-      // fail. To work around this, we retry a few times with some delay.
-      retry: 10,
-      retryDelay: 5_000,
-      retryStatusCodes: [400, 500, 502, 503, 504],
-      // empty method to avoid spamming the console with HTML error responses
-      // from the server while retrying
-      onResponseError: async () => {},
-    });
   }
 
-  /**
-   * Submit given version for moderation review
-   */
-  public async submitVersion(params: {
-    packageId: number;
-    versionNumber: string;
-  }): Promise<OperaAddonVersionDetails | OperaAddonApiError> {
-    const endpoint = this.submitVersionEndpoint(
-      params.packageId,
-      params.versionNumber,
-    );
-
-    return fetch(endpoint, {
-      method: 'POST',
-      headers: {
-        accept: 'application/json; version=1.0',
-        'x-csrftoken': this.csrfToken,
-        Referer: `https://addons.opera.com/developer/package/${params.packageId}/version/${params.versionNumber}?language=en`,
-        cookie: `INGRESSCOOKIE_API; sessionid=${this.sessionId}; csrftoken=${this.csrfToken};`,
-      },
-      body: undefined, // No body required
-    });
+  export interface FileValidationRequest {
+    file_id: string;
+    file_name: string;
+    metadata_from: string;
   }
 
-  // Opera uses the standard Django CSRF token, which is a 32-character-long random string.
-  // In the context of this API, we can just use a fixed string since it doesn't need to be valid.
-  // See : https://docs.djangoproject.com/en/4.2/ref/csrf/#ajax for more details about how Django CSRF tokens work.
-  private generateCSRFToken = () => '12345678901234567890123456789012';
+  export type Endpoints = {
+    GET: {
+      /**
+       * Get the detailed information about an Opera Addon.
+       */
+      '/api/developer/packages/{packageId}/': {
+        params: {
+          packageId: number;
+        };
+        response: {
+          type: 'json';
+          value: OperaAddonDetails | OperaAddonApiError;
+        };
+      };
 
-  private generateFileIdentifier = (
-    size: number,
-    name: string,
-  ): `${number}-${string}` => `${size}-${name.replace(/[^0-9a-zA-Z_-]/g, '')}`;
-
-  private async fileInfo(filepath: string) {
-    const stat = await fs.promises.stat(filepath);
-    return {
-      path: filepath,
-      name: path.basename(filepath),
-      size: stat.size,
+      /**
+       * Get the detailed information about a specific Opera Addon version.
+       */
+      '/api/developer/package-versions/{packageId}-{version}/': {
+        params: {
+          packageId: number;
+          version: string;
+        };
+        response: {
+          type: 'json';
+          value: OperaAddonVersionDetails | OperaAddonApiError;
+        };
+      };
     };
-  }
+    POST: {
+      /**
+       * Upload a chunk of a new package version for an Opera Addon.
+       */
+      '/api/file-upload/': {
+        body: Readable;
+        response: { type: 'json'; value: void };
+      };
+
+      /**
+       * Bind an uploaded file to an addon package and validate it.
+       */
+      '/api/developer/package-versions/': {
+        query: {
+          package_id: number;
+        };
+        body: FileValidationRequest;
+        response: {
+          type: 'json';
+          value: OperaAddonFileValidationResponse | OperaAddonApiError;
+        };
+      };
+
+      /**
+       * Submit a given version for moderation review.
+       *
+       * Trailing slash is required - Opera's backend (Django) has
+       * APPEND_SLASH=True, so a request without it gets 301-redirected, and
+       * fetch will follow the redirect as a GET, causing a 405.
+       */
+      '/api/developer/package-versions/{packageId}-{version}/submit_for_moderation/': {
+        params: {
+          packageId: number;
+          version: string;
+        };
+        response: {
+          type: 'json';
+          value: OperaAddonVersionDetails | OperaAddonApiError;
+        };
+      };
+    };
+    PATCH: {
+      /**
+       * Update the details of a specific Opera Addon version.
+       */
+      '/api/developer/package-versions/{packageId}-{version}/': {
+        params: {
+          packageId: number;
+          version: string;
+        };
+        body: DeepPartial<OperaAddonVersionDetails>;
+        response: {
+          type: 'json';
+          value: OperaAddonVersionDetails | OperaAddonApiError;
+        };
+      };
+    };
+  };
 }

--- a/src/stores/opera-addons-store.ts
+++ b/src/stores/opera-addons-store.ts
@@ -1,26 +1,47 @@
 import type { Store } from './store';
 import { ensureZipExists } from '../utils/fs';
-import { OperaAddonsApi } from '../apis/opera-api';
+import { createHttpClient, type HttpClient } from '../utils/http-client';
+import { OperaApi } from '../apis/opera-api';
+import { pollUntil } from '../utils/polling';
+import { FormData } from 'formdata-node';
+import { FormDataEncoder } from 'form-data-encoder';
+import { Readable } from 'node:stream';
+import { Blob } from 'node:buffer';
+import fs from 'node:fs';
+import path from 'node:path';
 import type { OperaAddonsStoreOptions } from '../config';
 
 export class OperaAddonsStore implements Store {
-  private api: OperaAddonsApi;
+  private client: HttpClient<OperaApi.Endpoints>;
+
+  // Opera uses the standard Django CSRF token, which is a 32-character-long
+  // random string. In the context of this API, we can just use a fixed string
+  // since it doesn't need to be valid.
+  // See : https://docs.djangoproject.com/en/4.2/ref/csrf/#ajax for more details
+  // about how Django CSRF tokens work.
+  private readonly csrfToken = '12345678901234567890123456789012';
 
   constructor(
     readonly options: OperaAddonsStoreOptions,
     readonly setStatus: (text: string) => void,
   ) {
-    this.api = new OperaAddonsApi({
-      sessionId: this.options.sessionId,
+    this.client = createHttpClient<OperaApi.Endpoints>({
+      baseUrl: OperaApi.BASE_URL,
+      defaultHeaders: () => ({
+        accept: 'application/json; version=1.0',
+        'x-csrftoken': this.csrfToken,
+        cookie: `INGRESSCOOKIE_API; sessionid=${this.options.sessionId}; csrftoken=${this.csrfToken};`,
+      }),
     });
   }
 
   async submit(dryRun?: boolean): Promise<void> {
     this.setStatus('Getting addon details');
 
-    const addon = await this.api.getAddonDetails({
-      packageId: this.options.packageId,
-    });
+    const addon = await this.client.get(
+      '/api/developer/packages/{packageId}/',
+      { params: { packageId: this.options.packageId } },
+    );
 
     if ('detail' in addon) {
       throw new Error(addon.detail);
@@ -40,10 +61,15 @@ export class OperaAddonsStore implements Store {
     // almost all the details from the previous version, except for the
     // "short summary" field. So we need to copy that part ourselves by
     // reusing the previous version's details
-    const previousVersionDetails = await this.api.getAddonVersionDetails({
-      packageId: this.options.packageId,
-      version: previousVersion,
-    });
+    const previousVersionDetails = await this.client.get(
+      '/api/developer/package-versions/{packageId}-{version}/',
+      {
+        params: {
+          packageId: this.options.packageId,
+          version: previousVersion,
+        },
+      },
+    );
 
     if ('detail' in previousVersionDetails) {
       throw new Error(previousVersionDetails.detail);
@@ -64,17 +90,13 @@ export class OperaAddonsStore implements Store {
 
     this.setStatus('Uploading new version from zip');
 
-    const creationData = await this.api.uploadFile({
-      packageId: this.options.packageId,
-      file: this.options.zip,
-    });
+    const creationData = await this.uploadZip();
 
     this.setStatus(
       `File uploaded (fileId: ${creationData.fileId}), waiting for validation results...`,
     );
 
-    const validationResult = await this.api.validateFileUpload({
-      packageId: this.options.packageId,
+    const validationResult = await this.validateFileUpload({
       lastVersion: previousVersion,
       ...creationData,
     });
@@ -87,18 +109,27 @@ export class OperaAddonsStore implements Store {
 
     // As said above, we need to copy the previous version short summary/description
     // details to the new version
-    const updatedDetails = await this.api.updateAddonVersionDetails({
-      packageId: this.options.packageId,
-      version: validationResult.version,
-      details: {
-        translations: {
-          en: {
-            short_description:
-              previousVersionDetails.translations.en!.short_description,
+    const updatedDetails = await this.client.fetch(
+      'PATCH',
+      '/api/developer/package-versions/{packageId}-{version}/',
+      {
+        params: {
+          packageId: this.options.packageId,
+          version: validationResult.version,
+        },
+        headers: {
+          Referer: `https://addons.opera.com/developer/package/${this.options.packageId}/version/${validationResult.version}`,
+        },
+        body: {
+          translations: {
+            en: {
+              short_description:
+                previousVersionDetails.translations.en!.short_description,
+            },
           },
         },
       },
-    });
+    );
 
     if ('detail' in updatedDetails) {
       throw new Error(updatedDetails.detail);
@@ -115,10 +146,18 @@ export class OperaAddonsStore implements Store {
 
     // For some reasons (again), this request takes about 2 min
     // to be processed by Opera's API
-    const res = await this.api.submitVersion({
-      packageId: this.options.packageId,
-      versionNumber: validationResult.version,
-    });
+    const res = await this.client.post(
+      '/api/developer/package-versions/{packageId}-{version}/submit_for_moderation/',
+      {
+        params: {
+          packageId: this.options.packageId,
+          version: validationResult.version,
+        },
+        headers: {
+          Referer: `https://addons.opera.com/developer/package/${this.options.packageId}/version/${validationResult.version}?language=en`,
+        },
+      },
+    );
 
     if ('detail' in res) {
       throw new Error(res.detail);
@@ -127,5 +166,114 @@ export class OperaAddonsStore implements Store {
 
   async ensureZipsExist(): Promise<void> {
     await ensureZipExists(this.options.zip);
+  }
+
+  /**
+   * Upload the extension zip to Opera in chunks, returning the identifier used
+   * to bind the uploaded file to the addon package.
+   */
+  private async uploadZip(): Promise<OperaApi.FileUploadResponse> {
+    const fileInfo = await this.fileInfo(this.options.zip);
+
+    const chunkSize = 1024 * 1024;
+    const totalChunks = Math.ceil(fileInfo.size / chunkSize);
+
+    const identifier = this.generateFileIdentifier(
+      fileInfo.size,
+      fileInfo.name,
+    );
+
+    const stream = fs.createReadStream(this.options.zip, {
+      highWaterMark: chunkSize,
+    });
+
+    let chunkNumber = 1;
+
+    for await (const chunk of stream) {
+      const form = new FormData();
+
+      form.append('file', new Blob([chunk]), fileInfo.name);
+
+      form.append('flowChunkNumber', String(chunkNumber));
+      form.append('flowChunkSize', String(chunkSize));
+      form.append('flowCurrentChunkSize', String(chunk.length));
+      form.append('flowTotalSize', String(fileInfo.size));
+      form.append('flowIdentifier', identifier);
+      form.append('flowFilename', fileInfo.name);
+      form.append('flowRelativePath', fileInfo.name);
+      form.append('flowTotalChunks', String(totalChunks));
+
+      const encoder = new FormDataEncoder(form);
+
+      await this.client.post('/api/file-upload/', {
+        headers: {
+          ...encoder.headers,
+          Referer: `https://addons.opera.com/developer/package/${this.options.packageId}/`,
+        },
+        body: Readable.from(encoder),
+        // The chunk upload responses aren't JSON, so skip parsing the body -
+        // the http client still throws on non-2xx responses.
+        mapResponse: async () => {},
+      });
+
+      chunkNumber++;
+    }
+
+    return {
+      fileId: identifier,
+      fileName: fileInfo.name,
+    };
+  }
+
+  /**
+   * Bind an uploaded file to an addon package and wait for validation.
+   */
+  private async validateFileUpload(params: {
+    fileId: `${number}-${string}`;
+    fileName: string;
+    lastVersion: string;
+  }) {
+    let lastError: unknown;
+
+    // There might be some delay between the upload file request finishing and
+    // the file being actually available for validation, so the request might
+    // fail. To work around this, we retry a few times with some delay.
+    return await pollUntil(
+      async () => {
+        try {
+          return await this.client.post('/api/developer/package-versions/', {
+            query: { package_id: this.options.packageId },
+            headers: {
+              Referer: `https://addons.opera.com/developer/package/${this.options.packageId}/`,
+            },
+            body: {
+              file_id: params.fileId,
+              file_name: params.fileName,
+              metadata_from: params.lastVersion,
+            },
+          });
+        } catch (err) {
+          lastError = err;
+          return undefined;
+        }
+      },
+      { interval: 5_000, timeout: 60_000 },
+    ).catch(() => {
+      throw lastError ?? new Error('Failed to validate the uploaded file');
+    });
+  }
+
+  private generateFileIdentifier = (
+    size: number,
+    name: string,
+  ): `${number}-${string}` => `${size}-${name.replace(/[^0-9a-zA-Z_-]/g, '')}`;
+
+  private async fileInfo(filepath: string) {
+    const stat = await fs.promises.stat(filepath);
+    return {
+      path: filepath,
+      name: path.basename(filepath),
+      size: stat.size,
+    };
   }
 }


### PR DESCRIPTION
This is the last API that was depending on `ofetch`, migrated to new API client pattern.