### PR TITLE
chore: Replace `listr2` with `tasuku`

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,7 +36,11 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup
-      - run: bun dev:all
+      - run: |
+          bun dev:chrome
+          # bun dev:firefox
+          bun dev:edge
+          bun dev:opera
         env:
           # Chrome
           CHROME_EXTENSION_ID: ${{ secrets.TEST_CHROME_EXTENSION_ID }}

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "dotenv": "^17.2.4",
         "form-data-encoder": "^4.1.0",
         "formdata-node": "^6.0.3",
-        "listr2": "^10.1.0",
+        "tasuku": "^2.3.0",
       },
       "devDependencies": {
         "@aklinker1/check": "^2.2.0",
@@ -408,13 +408,13 @@
 
     "lint-staged": ["lint-staged@16.2.7", "", { "dependencies": { "commander": "^14.0.2", "listr2": "^9.0.5", "micromatch": "^4.0.8", "nano-spawn": "^2.0.0", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.8.1" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow=="],
 
-    "listr2": ["listr2@10.1.0", "", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^7.0.2", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-/6t2KgDYIcCjhELwvrRxi1gaJ4xCGLTjNvh6mSjYenBkrZxggek8EwCbwBU33GMUCpyyrOzz2TzylrO5mTiI1w=="],
+    "listr2": ["listr2@9.0.5", "", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g=="],
 
     "load-json-file": ["load-json-file@4.0.0", "", { "dependencies": { "graceful-fs": "^4.1.2", "parse-json": "^4.0.0", "pify": "^3.0.0", "strip-bom": "^3.0.0" } }, "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw=="],
 
     "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
-    "log-update": ["log-update@7.1.0", "", { "dependencies": { "ansi-escapes": "^7.1.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.2", "strip-ansi": "^7.1.2", "wrap-ansi": "^9.0.2" } }, "sha512-y9pi/ZOQQVvTgfRDEHV1Cj4zQUkJZPipEUNOxhn1R6KgmdMs7LKvXWCd9eMVPGJgvYzFLCenecWr0Ps8ChVv2A=="],
+    "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -596,6 +596,8 @@
 
     "tar-stream": ["tar-stream@3.1.7", "", { "dependencies": { "b4a": "^1.6.4", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ=="],
 
+    "tasuku": ["tasuku@2.3.0", "", {}, "sha512-9Jtk+XAnttslCw4i9RceSZGr2PT5TLn0vUyWnoP2SdlSYzkiYRY6kB5qnPi5IQ/Em8e4oBow1rpaA39iijTIrA=="],
+
     "text-decoder": ["text-decoder@1.2.3", "", { "dependencies": { "b4a": "^1.6.4" } }, "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA=="],
 
     "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
@@ -662,8 +664,6 @@
 
     "lazystream/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
-    "lint-staged/listr2": ["listr2@9.0.5", "", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g=="],
-
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "normalize-package-data/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
@@ -713,8 +713,6 @@
     "lazystream/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "lazystream/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
-
-    "lint-staged/listr2/log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
     "readdir-glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dotenv": "^17.2.4",
     "form-data-encoder": "^4.1.0",
     "formdata-node": "^6.0.3",
-    "listr2": "^10.1.0"
+    "tasuku": "^2.3.0"
   },
   "devDependencies": {
     "@aklinker1/check": "^2.2.0",

--- a/src/commands/submit.ts
+++ b/src/commands/submit.ts
@@ -1,4 +1,4 @@
-import { Listr } from 'listr2';
+import { task } from '../utils/task-list';
 import { ChromeWebStoreV1_1 } from '../stores/chrome-web-store-v1.1';
 import { type InlineConfig, resolveConfig, validateConfig } from '../config';
 import { EdgeAddonStoreV1_1 } from '../stores/edge-addon-store-v1.1';
@@ -73,46 +73,38 @@ export async function submit(config: InlineConfig): Promise<SubmitResults> {
   // Execute the tasks
 
   const results: SubmitResults = {};
-  const tasks = new Listr(
-    stores.map(({ id, name, getStore }) => ({
-      title: name,
-      async task(_ctx, task) {
+  await Promise.allSettled(
+    stores.map(({ id, name, getStore }) =>
+      task(id, name, async t => {
         try {
-          const setStatus = (text: string) => {
-            task.output = `[${id}] ${text}`;
-          };
-          const store = getStore(setStatus);
+          const store = getStore(t.setOutput);
 
-          setStatus('Checking ZIP files exist');
+          t.setOutput('Checking ZIP files exist');
           await store.ensureZipsExist();
+
           await store.submit(internalConfig.dryRun);
+
           results[id] = { success: true };
         } catch (err) {
           results[id] = { success: false, err: err };
           throw err;
         }
-      },
-    })),
-    {
-      exitOnError: false,
-      collectErrors: 'minimal',
-      concurrent: true,
-    },
+      }),
+    ),
   );
-  await tasks.run();
 
   // Check for errors
 
-  const errors = Object.entries(results).filter(([_id, result]) => {
-    return !result.success;
-  });
-  if (errors.length > 0) {
-    // Listr already logs the errors, just show a summary at the end
-    throw Error(`Submissions failed: ${errors.length}`);
+  const errors = Object.values(results).reduce(
+    (count, res) => count + (res.success ? 0 : 1),
+    0,
+  );
+  if (errors > 0) {
+    // Tasuku already logs the errors, just show a count at the end
+    throw Error(`Submissions failed: ${errors}`);
   }
 
   // Return the results
-
   return results;
 }
 

--- a/src/utils/task-list.ts
+++ b/src/utils/task-list.ts
@@ -9,12 +9,11 @@ export async function task<T>(
   fn: (task: Task) => Promise<T>,
 ): Promise<void> {
   // Use Tasuku for nice animations when possible
-  // if (process.stdout.isTTY && !process.env.CI) {
-  if (true) {
+  if (process.stdout.isTTY && !process.env.CI) {
     return tasuku(name, fn).then(() => {});
   }
 
-  // Otherwise, use consola
+  // Otherwise, use consola. Tasuku doesn't log anything in these environments
   consola.start(name);
   const t: Task = {
     setOutput: text => consola.log(`\x1b[2m  → [${String(id)}] ${text}\x1b[0m`),

--- a/src/utils/task-list.ts
+++ b/src/utils/task-list.ts
@@ -9,7 +9,8 @@ export async function task<T>(
   fn: (task: Task) => Promise<T>,
 ): Promise<void> {
   // Use Tasuku for nice animations when possible
-  if (process.stdout.isTTY && !process.env.CI) {
+  // if (process.stdout.isTTY && !process.env.CI) {
+  if (true) {
     return tasuku(name, fn).then(() => {});
   }
 

--- a/src/utils/task-list.ts
+++ b/src/utils/task-list.ts
@@ -1,0 +1,28 @@
+import consola from 'consola';
+import tasuku from 'tasuku';
+
+export type Task = { setOutput: (text: string) => void };
+
+export async function task<T>(
+  id: any,
+  name: string,
+  fn: (task: Task) => Promise<T>,
+): Promise<void> {
+  // Use Tasuku for nice animations when possible
+  if (process.stdout.isTTY && !process.env.CI) {
+    return tasuku(name, fn).then(() => {});
+  }
+
+  // Otherwise, use consola
+  consola.start(name);
+  const t: Task = {
+    setOutput: text => consola.log(`\x1b[2m  → [${String(id)}] ${text}\x1b[0m`),
+  };
+  try {
+    await fn(t);
+    consola.success(name);
+  } catch (err) {
+    consola.error(name, err);
+    throw err;
+  }
+}


### PR DESCRIPTION
Apart of #76, replace listr2 with tasuku. Tasuku doesn't ship a renderer for non-tty output, so I made a simple one with consola.

New look:

<img width="1166" height="318" alt="tty" src="https://github.com/user-attachments/assets/a5826b6c-f6da-4204-8c3e-3a39e10316cf" />
<img width="1392" height="900" alt="ci" src="https://github.com/user-attachments/assets/11ab7b60-2641-44c8-bc20-c04219b6505a" />
