### PR TITLE
chore: Replace `dotenv` with node built-ins

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,6 @@
       "dependencies": {
         "cac": "^6.7.14",
         "consola": "^3.4.2",
-        "dotenv": "^17.2.4",
         "form-data-encoder": "^4.1.0",
         "formdata-node": "^6.0.3",
         "tasuku": "^2.3.0",
@@ -235,8 +234,6 @@
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
-
-    "dotenv": ["dotenv@17.2.4", "", {}, "sha512-mudtfb4zRB4bVvdj0xRo+e6duH1csJRM8IukBqfTRvHotn9+LBXB8ynAidP9zHqoRC/fsllXgk4kCKlR21fIhw=="],
 
     "dts-resolver": ["dts-resolver@2.1.3", "", { "peerDependencies": { "oxc-resolver": ">=11.0.0" }, "optionalPeers": ["oxc-resolver"] }, "sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw=="],
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "cac": "^6.7.14",
     "consola": "^3.4.2",
-    "dotenv": "^17.2.4",
     "form-data-encoder": "^4.1.0",
     "formdata-node": "^6.0.3",
     "tasuku": "^2.3.0"
@@ -95,6 +94,6 @@
     }
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.12.0"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,12 +3,20 @@ import { version } from '../package.json';
 import { submit } from './commands/submit';
 import { init } from './commands/init';
 import { consola } from 'consola';
-import { config } from 'dotenv';
+import { readFileSync } from 'node:fs';
+import { parseEnv } from 'node:util';
 import type { InlineConfig } from './config';
 import { status } from './commands/status';
 import { setDeployPercentage } from './commands/set-deploy-percentage';
 
-config({ path: '.env.submit', quiet: true });
+try {
+  const env = parseEnv(readFileSync('.env.submit', 'utf8'));
+  for (const [key, value] of Object.entries(env)) {
+    process.env[key] ??= value;
+  }
+} catch {
+  // Ignore missing or unreadable .env.submit file
+}
 
 const cli = cac('publish-extension');
 cli.version(version);


### PR DESCRIPTION
Apart of #76 

Merge this before the next breaking change. Probably in october when we drop support for CWS API v1.1.