### PR TITLE
chore: Inline deps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,11 +4,9 @@
   "workspaces": {
     "": {
       "name": "publish-browser-extension",
-      "dependencies": {
-        "@topcli/prompts": "^4.0.0",
-      },
       "devDependencies": {
         "@aklinker1/check": "^2.4.0",
+        "@topcli/prompts": "^4.0.0",
         "@types/archiver": "^8.0.0",
         "@types/bun": "^1.3.14",
         "@types/node": "^26.1.0",

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,6 @@
       "name": "publish-browser-extension",
       "dependencies": {
         "@topcli/prompts": "^4.0.0",
-        "cac": "^7.0.0",
       },
       "devDependencies": {
         "@aklinker1/check": "^2.4.0",
@@ -15,6 +14,7 @@
         "@types/node": "^26.1.0",
         "@typescript/native-preview": "^7.0.0-dev.20260705.1",
         "archiver": "^8.0.0",
+        "cac": "^7.0.0",
         "lint-staged": "^17.0.8",
         "oxlint": "^1.72.0",
         "prettier": "^3.9.4",

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,6 @@
       "dependencies": {
         "@topcli/prompts": "^4.0.0",
         "cac": "^7.0.0",
-        "tasuku": "^2.3.0",
       },
       "devDependencies": {
         "@aklinker1/check": "^2.4.0",
@@ -23,6 +22,7 @@
         "scule": "^1.3.0",
         "simple-git-hooks": "^2.13.1",
         "superstruct": "^2.0.2",
+        "tasuku": "^2.3.0",
         "tsdown": "^0.22.3",
         "typescript": "^6.0.3",
       },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "check": "check",
     "build": "bun run --sequential 'build:*'",
-    "build:lib": "tsdown src/index.ts src/cli.ts --deps.onlyBundle superstruct",
+    "build:lib": "tsdown src/index.ts src/cli.ts --deps.onlyBundle superstruct --deps.onlyBundle tasuku",
     "build:test-extension": "bun scripts/build-test-extension.ts",
     "dev:all": "bun ./scripts/dev.ts all",
     "dev:chrome": "bun ./scripts/dev.ts chrome",
@@ -28,8 +28,7 @@
   },
   "dependencies": {
     "@topcli/prompts": "^4.0.0",
-    "cac": "^7.0.0",
-    "tasuku": "^2.3.0"
+    "cac": "^7.0.0"
   },
   "devDependencies": {
     "@aklinker1/check": "^2.4.0",
@@ -45,6 +44,7 @@
     "scule": "^1.3.0",
     "simple-git-hooks": "^2.13.1",
     "superstruct": "^2.0.2",
+    "tasuku": "^2.3.0",
     "tsdown": "^0.22.3",
     "typescript": "^6.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "check": "check",
     "build": "bun run --sequential 'build:*'",
-    "build:lib": "tsdown src/index.ts src/cli.ts --deps.onlyBundle superstruct --deps.onlyBundle tasuku --deps.onlyBundle cac",
+    "build:lib": "tsdown src/index.ts src/cli.ts --deps.onlyBundle superstruct --deps.onlyBundle tasuku --deps.onlyBundle cac --deps.onlyBundle @topcli/prompts",
     "build:test-extension": "bun scripts/build-test-extension.ts",
     "dev:all": "bun ./scripts/dev.ts all",
     "dev:chrome": "bun ./scripts/dev.ts chrome",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "check": "check",
     "build": "bun run --sequential 'build:*'",
-    "build:lib": "tsdown src/index.ts src/cli.ts --deps.onlyBundle superstruct --deps.onlyBundle tasuku",
+    "build:lib": "tsdown src/index.ts src/cli.ts --deps.onlyBundle superstruct --deps.onlyBundle tasuku --deps.onlyBundle cac",
     "build:test-extension": "bun scripts/build-test-extension.ts",
     "dev:all": "bun ./scripts/dev.ts all",
     "dev:chrome": "bun ./scripts/dev.ts chrome",
@@ -27,8 +27,7 @@
     "gen:cws-v2": "bun run scripts/gen-cws-api.ts v2"
   },
   "dependencies": {
-    "@topcli/prompts": "^4.0.0",
-    "cac": "^7.0.0"
+    "@topcli/prompts": "^4.0.0"
   },
   "devDependencies": {
     "@aklinker1/check": "^2.4.0",
@@ -37,6 +36,7 @@
     "@types/node": "^26.1.0",
     "@typescript/native-preview": "^7.0.0-dev.20260705.1",
     "archiver": "^8.0.0",
+    "cac": "^7.0.0",
     "lint-staged": "^17.0.8",
     "oxlint": "^1.72.0",
     "prettier": "^3.9.4",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,9 @@
     "gen:cws-v1.1": "bun run scripts/gen-cws-api.ts v1.1",
     "gen:cws-v2": "bun run scripts/gen-cws-api.ts v2"
   },
-  "dependencies": {
-    "@topcli/prompts": "^4.0.0"
-  },
   "devDependencies": {
     "@aklinker1/check": "^2.4.0",
+    "@topcli/prompts": "^4.0.0",
     "@types/archiver": "^8.0.0",
     "@types/bun": "^1.3.14",
     "@types/node": "^26.1.0",


### PR DESCRIPTION
## Current `main`: 

<img width="1033" height="171" alt="Screenshot 2026-07-28 at 2 13 05 PM" src="https://github.com/user-attachments/assets/eeb7cc71-4b58-44f9-8da1-6aeccd2f9752" />

## Inline `tasuku`: [source](https://pkg-size.dev/https:%2F%2Fpkg.pr.new%2Fpublish-browser-extension@eb18a59)

<img width="1018" height="167" alt="Screenshot 2026-07-28 at 2 13 46 PM" src="https://github.com/user-attachments/assets/2456668c-d439-4e57-9a89-7b116d3381ce" />

## Inline `tasuku`, `cac`: [source](https://pkg-size.dev/https:%2F%2Fpkg.pr.new%2Fpublish-browser-extension@eb18a59)

<img width="1024" height="160" alt="Screenshot 2026-07-28 at 2 14 03 PM" src="https://github.com/user-attachments/assets/015cad41-93c3-413c-8d3d-9f4f3e0e8a2c" />

## Inline `tasuku`, `cac`, `@topcli/prompts`: [source](https://pkg-size.dev/https:%2F%2Fpkg.pr.new%2Fpublish-browser-extension@b0c37f9)

<img width="1040" height="163" alt="Screenshot 2026-07-28 at 2 14 16 PM" src="https://github.com/user-attachments/assets/7cc2f8f3-9397-458c-b23d-31b573cbd269" />

---

So we _could_ reduce the size from 333 kB to 229 kB, 68% the previous size. However, I don't particularly think inlining everything makes sense here. If we inline them, then if multiple packages in `node_modules` that depend on it would re-download them. So inlining doesn't always save space in the long term.

For now, I'm going to not inline anything.