### PR TITLE
feat: support Firefox AMO metadata

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -234,7 +234,7 @@ Example:
 ```jsonc
 {
   "version": {
-    // Version-specific fields go in the "version" field.
+    // Version-specific fields go in the "version" field
     // https://mozilla.github.io/addons-server/topics/api/addons.html#version-create
     "release_notes": "...",
   },

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -227,7 +227,7 @@ Path to extension zip to upload
 
 ### `firefox.amoMetadataFile`
 
-Path to a JSON file containing AMO listing and version metadata
+Path to JSON with AMO add-on edit fields at the top level and version create fields under "version": https://mozilla.github.io/addons-server/topics/api/addons.html#edit and https://mozilla.github.io/addons-server/topics/api/addons.html#version-create
 
 - _CLI Flag_: `--firefox-amo-metadata-file`
 - _Env Var_: `FIREFOX_AMO_METADATA_FILE`

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -227,7 +227,22 @@ Path to extension zip to upload
 
 ### `firefox.amoMetadataFile`
 
-Path to JSON with AMO add-on edit fields at the top level and version create fields under "version": https://mozilla.github.io/addons-server/topics/api/addons.html#edit and https://mozilla.github.io/addons-server/topics/api/addons.html#version-create
+Path to a JSON file with metadata to update.
+
+Example:
+
+```jsonc
+{
+  "version": {
+    // Version-specific fields go in the "version" field.
+    // https://mozilla.github.io/addons-server/topics/api/addons.html#version-create
+    "release_notes": "...",
+  },
+  // General addon fields go in the root
+  // https://mozilla.github.io/addons-server/topics/api/addons.html#edit
+  "description": "...",
+}
+```
 
 - _CLI Flag_: `--firefox-amo-metadata-file`
 - _Env Var_: `FIREFOX_AMO_METADATA_FILE`

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -24,6 +24,7 @@
 - [`edge.productId`](#edgeproductid)
 - [`edge.skipSubmitReview`](#edgeskipsubmitreview)
 - [`edge.zip`](#edgezip)
+- [`firefox.amoMetadataFile`](#firefoxamometadatafile)
 - [`firefox.channel`](#firefoxchannel)
 - [`firefox.compatibility`](#firefoxcompatibility)
 - [`firefox.extensionId`](#firefoxextensionid)
@@ -223,6 +224,13 @@ Path to extension zip to upload
 
 - _CLI Flag_: `--edge-zip`
 - _Env Var_: `EDGE_ZIP`
+
+### `firefox.amoMetadataFile`
+
+Path to a JSON file containing AMO listing and version metadata
+
+- _CLI Flag_: `--firefox-amo-metadata-file`
+- _Env Var_: `FIREFOX_AMO_METADATA_FILE`
 
 ### `firefox.channel`
 

--- a/scripts/gen-config-docs.ts
+++ b/scripts/gen-config-docs.ts
@@ -20,7 +20,7 @@ const lines = [
       ...(defaultValue
         ? [`**Default:** \`${JSON.stringify(defaultValue)}\``, '']
         : []),
-      meta.description,
+      meta.extendedDescription ?? meta.description,
       '',
       `- _CLI Flag_: \`--${kebabCase(meta.path)}\``,
       `- _Env Var_: \`${snakeCase(meta.path).toUpperCase()}\``,

--- a/scripts/gen-config-env.ts
+++ b/scripts/gen-config-env.ts
@@ -6,8 +6,14 @@ const lines: string[] = [];
 
 lines.push('export interface CustomEnv {');
 for (const meta of configMetas) {
+  const description =
+    `${meta.note ? `[${meta.note}] ` : ''}${meta.extendedDescription ?? meta.description}`.split(
+      '\n',
+    );
   lines.push(
-    `  /** ${meta.note ? `[${meta.note}] ` : ''}${meta.description} */`,
+    ...(description.length === 1
+      ? [`  /** ${description[0]} */`]
+      : ['  /**', ...description.map(line => '   * ' + line), '   */']),
     `  ${snakeCase(meta.path).toUpperCase()}: string | undefined,`,
   );
 }

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -42,6 +42,7 @@ describe('resolveConfig', () => {
         channel: 'unlisted',
         zip: 'zip',
         sourcesZip: 'sourcesZip',
+        amoMetadataFile: 'amoMetadataFile',
         skipSubmitReview: true,
       },
       edge: {
@@ -87,6 +88,7 @@ describe('resolveConfig', () => {
 
     process.env.FIREFOX_ZIP = 'FIREFOX_ZIP';
     process.env.FIREFOX_SOURCES_ZIP = 'FIREFOX_SOURCES_ZIP';
+    process.env.FIREFOX_AMO_METADATA_FILE = 'FIREFOX_AMO_METADATA_FILE';
     process.env.FIREFOX_EXTENSION_ID = 'FIREFOX_EXTENSION_ID';
     process.env.FIREFOX_JWT_ISSUER = 'FIREFOX_JWT_ISSUER';
     process.env.FIREFOX_JWT_SECRET = 'FIREFOX_JWT_SECRET';
@@ -134,6 +136,7 @@ describe('resolveConfig', () => {
       firefox: {
         zip: process.env.FIREFOX_ZIP,
         sourcesZip: process.env.FIREFOX_SOURCES_ZIP,
+        amoMetadataFile: process.env.FIREFOX_AMO_METADATA_FILE,
         channel: firefoxChannel,
         extensionId: process.env.FIREFOX_EXTENSION_ID,
         jwtIssuer: process.env.FIREFOX_JWT_ISSUER,

--- a/src/__tests__/firefox-addon-store-v5.test.ts
+++ b/src/__tests__/firefox-addon-store-v5.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FirefoxAddonStoreV5 } from '../stores/firefox-addon-store-v5';
+
+const originalFetch = globalThis.fetch;
+
+describe('FirefoxAddonStoreV5', () => {
+  let directory: string;
+  let zip: string;
+  let metadataFile: string;
+
+  beforeEach(async () => {
+    directory = await mkdtemp(join(tmpdir(), 'publish-browser-extension-'));
+    zip = join(directory, 'extension.zip');
+    metadataFile = join(directory, 'amo-metadata.json');
+    await writeFile(zip, 'zip');
+    await writeFile(
+      metadataFile,
+      JSON.stringify({
+        summary: { 'en-US': 'Updated summary' },
+        version: {
+          license: 'MPL-2.0',
+          release_notes: { 'en-US': 'Fixed a bug' },
+        },
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = originalFetch;
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  it('submits AMO listing and version metadata', async () => {
+    const requests: Array<{ url: string; init: RequestInit }> = [];
+    globalThis.fetch = mock(
+      async (input: string | URL | Request, init: RequestInit = {}) => {
+        const url = String(input);
+        requests.push({ url, init });
+
+        if (
+          init.method === 'GET' &&
+          url.endsWith('/api/v5/addons/addon/test-extension')
+        ) {
+          return jsonResponse({ id: 'test-addon' });
+        }
+        if (init.method === 'POST' && url.endsWith('/api/v5/addons/upload/')) {
+          return jsonResponse({
+            uuid: 'upload-uuid',
+            channel: 'listed',
+            processed: false,
+            submitted: false,
+            url: '',
+            valid: true,
+            validation: { errors: 0, warnings: 0, notices: 0 },
+            version: '1.0.0',
+          });
+        }
+        if (
+          init.method === 'GET' &&
+          url.endsWith('/api/v5/addons/upload/upload-uuid')
+        ) {
+          return jsonResponse({
+            uuid: 'upload-uuid',
+            channel: 'listed',
+            processed: true,
+            submitted: false,
+            url: '',
+            valid: true,
+            validation: { errors: 0, warnings: 0, notices: 0 },
+            version: '1.0.0',
+          });
+        }
+        if (
+          init.method === 'PATCH' &&
+          url.endsWith('/api/v5/addons/addon/test-extension')
+        ) {
+          return jsonResponse({ id: 'test-addon' });
+        }
+        if (
+          init.method === 'POST' &&
+          url.endsWith('/api/v5/addons/addon/test-extension/versions/')
+        ) {
+          return jsonResponse({ id: 7, file: { id: 11 } });
+        }
+        throw Error(`Unexpected request: ${init.method} ${url}`);
+      },
+    ) as unknown as typeof fetch;
+
+    const store = new FirefoxAddonStoreV5(
+      {
+        zip,
+        amoMetadataFile: metadataFile,
+        extensionId: 'test-extension',
+        jwtIssuer: 'issuer',
+        jwtSecret: 'secret',
+        channel: 'listed',
+        skipSubmitReview: false,
+      },
+      () => {},
+    );
+
+    await store.submit();
+
+    const addonPatch = requests.find(
+      request =>
+        request.init.method === 'PATCH' &&
+        request.url.endsWith('/api/v5/addons/addon/test-extension'),
+    );
+    expect(JSON.parse(String(addonPatch?.init.body))).toEqual({
+      summary: { 'en-US': 'Updated summary' },
+    });
+
+    const versionPost = requests.find(
+      request =>
+        request.init.method === 'POST' &&
+        request.url.endsWith('/api/v5/addons/addon/test-extension/versions/'),
+    );
+    expect(JSON.parse(String(versionPost?.init.body))).toEqual({
+      upload: 'upload-uuid',
+      license: 'MPL-2.0',
+      release_notes: { 'en-US': 'Fixed a bug' },
+    });
+  }, 10_000);
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/src/apis/firefox-api-v5.ts
+++ b/src/apis/firefox-api-v5.ts
@@ -66,7 +66,7 @@ export type Endpoints = {
       params: {
         idOrSlugOrGuid: string | number;
       };
-      body: Bun.BodyInit;
+      body: Bun.BodyInit | Record<string, unknown>;
       response: { type: 'json'; value: AddonVersion };
     };
   };
@@ -76,9 +76,19 @@ export type Endpoints = {
         idOrSlugOrGuid: string | number;
         versionId: number;
       };
-      body: {
-        compatibility: string[];
+      body:
+        | FormData
+        | {
+            compatibility: string[];
+          };
+    };
+
+    '/api/v5/addons/addon/{idOrSlugOrGuid}': {
+      params: {
+        idOrSlugOrGuid: string | number;
       };
+      body: Record<string, unknown>;
+      response: { type: 'json'; value: AddonDetails };
     };
   };
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,7 @@ cli.help();
   cli.option('--edge-product-id [edgeProductId]', "Product ID listed on the developer dashboard")
   cli.option('--edge-skip-submit-review [edgeSkipSubmitReview]', "Just upload the extension zip, don't submit it for review or publish it (default: false)")
   cli.option('--edge-zip [edgeZip]', "Path to extension zip to upload")
-  cli.option('--firefox-amo-metadata-file [firefoxAmoMetadataFile]', "Path to a JSON file containing AMO listing and version metadata")
+  cli.option('--firefox-amo-metadata-file [firefoxAmoMetadataFile]', "Path to JSON with AMO add-on edit fields at the top level and version create fields under \"version\": https://mozilla.github.io/addons-server/topics/api/addons.html#edit and https://mozilla.github.io/addons-server/topics/api/addons.html#version-create")
   cli.option('--firefox-channel [firefoxChannel]', "The channel to publish to, \"listed\" or \"unlisted\" (default: \"listed\")")
   cli.option('--firefox-compatibility [firefoxCompatibility]', "Comma-separated list of compatible applications, e.g. \"firefox,android\" - \"firefox\" for compatibility with Firefox desktop apps, \"android\" for Firefox Android apps")
   cli.option('--firefox-extension-id [firefoxExtensionId]', "The ID of the extension to be submitted")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,7 +47,7 @@ cli.help();
   cli.option('--edge-product-id [edgeProductId]', "Product ID listed on the developer dashboard")
   cli.option('--edge-skip-submit-review [edgeSkipSubmitReview]', "Just upload the extension zip, don't submit it for review or publish it (default: false)")
   cli.option('--edge-zip [edgeZip]', "Path to extension zip to upload")
-  cli.option('--firefox-amo-metadata-file [firefoxAmoMetadataFile]', "Path to JSON with AMO add-on edit fields at the top level and version create fields under \"version\": https://mozilla.github.io/addons-server/topics/api/addons.html#edit and https://mozilla.github.io/addons-server/topics/api/addons.html#version-create")
+  cli.option('--firefox-amo-metadata-file [firefoxAmoMetadataFile]', "See: https://github.com/aklinker1/publish-browser-extension/blob/main/docs/config-reference.md#firefoxamometadatafile")
   cli.option('--firefox-channel [firefoxChannel]', "The channel to publish to, \"listed\" or \"unlisted\" (default: \"listed\")")
   cli.option('--firefox-compatibility [firefoxCompatibility]', "Comma-separated list of compatible applications, e.g. \"firefox,android\" - \"firefox\" for compatibility with Firefox desktop apps, \"android\" for Firefox Android apps")
   cli.option('--firefox-extension-id [firefoxExtensionId]', "The ID of the extension to be submitted")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -47,6 +47,7 @@ cli.help();
   cli.option('--edge-product-id [edgeProductId]', "Product ID listed on the developer dashboard")
   cli.option('--edge-skip-submit-review [edgeSkipSubmitReview]', "Just upload the extension zip, don't submit it for review or publish it (default: false)")
   cli.option('--edge-zip [edgeZip]', "Path to extension zip to upload")
+  cli.option('--firefox-amo-metadata-file [firefoxAmoMetadataFile]', "Path to a JSON file containing AMO listing and version metadata")
   cli.option('--firefox-channel [firefoxChannel]', "The channel to publish to, \"listed\" or \"unlisted\" (default: \"listed\")")
   cli.option('--firefox-compatibility [firefoxCompatibility]', "Comma-separated list of compatible applications, e.g. \"firefox,android\" - \"firefox\" for compatibility with Firefox desktop apps, \"android\" for Firefox Android apps")
   cli.option('--firefox-extension-id [firefoxExtensionId]', "The ID of the extension to be submitted")
@@ -96,6 +97,7 @@ function configFromFlags(flags: any): InlineConfig {
   config.edge.productId = flags.edgeProductId
   config.edge.skipSubmitReview = flags.edgeSkipSubmitReview
   config.edge.zip = flags.edgeZip
+  config.firefox.amoMetadataFile = flags.firefoxAmoMetadataFile
   config.firefox.channel = flags.firefoxChannel
   config.firefox.compatibility = flags.firefoxCompatibility
   config.firefox.extensionId = flags.firefoxExtensionId

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,6 +61,7 @@ export function resolveConfig(config?: InlineConfig): PartialResolvedConfig {
   if (raw.edge)    raw.edge.productId                   = (config as any)?.edge?.productId                   ?? process.env.EDGE_PRODUCT_ID
   if (raw.edge)    raw.edge.skipSubmitReview            = (config as any)?.edge?.skipSubmitReview            ?? process.env.EDGE_SKIP_SUBMIT_REVIEW
   if (raw.edge)    raw.edge.zip                         = (config as any)?.edge?.zip                         ?? process.env.EDGE_ZIP
+  if (raw.firefox) raw.firefox.amoMetadataFile          = (config as any)?.firefox?.amoMetadataFile          ?? process.env.FIREFOX_AMO_METADATA_FILE
   if (raw.firefox) raw.firefox.channel                  = (config as any)?.firefox?.channel                  ?? process.env.FIREFOX_CHANNEL
   if (raw.firefox) raw.firefox.compatibility            = (config as any)?.firefox?.compatibility            ?? process.env.FIREFOX_COMPATIBILITY
   if (raw.firefox) raw.firefox.extensionId              = (config as any)?.firefox?.extensionId              ?? process.env.FIREFOX_EXTENSION_ID

--- a/src/stores/firefox-addon-store-v5.ts
+++ b/src/stores/firefox-addon-store-v5.ts
@@ -6,6 +6,7 @@ import * as FirefoxApiV5 from '../apis/firefox-api-v5';
 import { createFirefoxJwt } from '../utils/firefox-auth';
 import { pollUntil } from '../utils/polling';
 import type { FirefoxAddonStoreV5Options } from '../config';
+import { readFile } from 'node:fs/promises';
 import { openAsBlob } from 'node:fs';
 
 export class FirefoxAddonStoreV5 implements Store {
@@ -31,6 +32,10 @@ export class FirefoxAddonStoreV5 implements Store {
   }
 
   async submit(dryRun?: boolean): Promise<void> {
+    const metadata = this.options.amoMetadataFile
+      ? await this.readMetadata(this.options.amoMetadataFile)
+      : undefined;
+
     this.setStatus('Getting addon details');
     const addon = await this.client.get(
       '/api/v5/addons/addon/{idOrSlugOrGuid}',
@@ -73,19 +78,63 @@ export class FirefoxAddonStoreV5 implements Store {
     }
 
     this.setStatus('Submitting new version');
-    const versionBody = new FormData();
-    versionBody.set('upload', upload.uuid);
-    versionBody.set(
-      'source',
-      this.options.sourcesZip ? await openAsBlob(this.options.sourcesZip) : '',
-    );
-    const version = await this.client.post(
-      '/api/v5/addons/addon/{idOrSlugOrGuid}/versions/',
-      {
-        params: { idOrSlugOrGuid: this.extensionId },
-        body: versionBody,
-      },
-    );
+    let version: FirefoxApiV5.AddonVersion;
+    if (metadata) {
+      const { version: versionMetadata = {}, ...addonMetadata } = metadata;
+      if (Object.keys(addonMetadata).length > 0) {
+        await this.client.fetch(
+          'PATCH',
+          '/api/v5/addons/addon/{idOrSlugOrGuid}',
+          {
+            params: { idOrSlugOrGuid: this.extensionId },
+            body: addonMetadata,
+          },
+        );
+      }
+
+      version = await this.client.post(
+        '/api/v5/addons/addon/{idOrSlugOrGuid}/versions/',
+        {
+          params: { idOrSlugOrGuid: this.extensionId },
+          body: {
+            upload: upload.uuid,
+            ...versionMetadata,
+          },
+        },
+      );
+
+      if (this.options.sourcesZip) {
+        const sourceBody = new FormData();
+        sourceBody.set('source', await openAsBlob(this.options.sourcesZip));
+        await this.client.fetch(
+          'PATCH',
+          '/api/v5/addons/addon/{idOrSlugOrGuid}/versions/{versionId}/',
+          {
+            params: {
+              idOrSlugOrGuid: this.extensionId,
+              versionId: version.id,
+            },
+            body: sourceBody,
+          },
+        );
+      }
+    } else {
+      const versionBody = new FormData();
+      versionBody.set('upload', upload.uuid);
+      versionBody.set(
+        'source',
+        this.options.sourcesZip
+          ? await openAsBlob(this.options.sourcesZip)
+          : '',
+      );
+      version = await this.client.post(
+        '/api/v5/addons/addon/{idOrSlugOrGuid}/versions/',
+        {
+          params: { idOrSlugOrGuid: this.extensionId },
+          body: versionBody,
+        },
+      );
+    }
 
     const validationUrl = `https://addons.mozilla.org/en-US/developers/addon/${addon.id}/file/${version.file.id}/validation`;
     if (!upload.valid) {
@@ -133,5 +182,25 @@ export class FirefoxAddonStoreV5 implements Store {
       plural(upload.validation.warnings, 'warning'),
       plural(upload.validation.notices, 'notice'),
     ].join(', ');
+  }
+
+  private async readMetadata(
+    path: string,
+  ): Promise<Record<string, unknown> & { version?: Record<string, unknown> }> {
+    const metadata = JSON.parse(await readFile(path, 'utf8'));
+    if (
+      metadata == null ||
+      typeof metadata !== 'object' ||
+      Array.isArray(metadata)
+    ) {
+      throw Error('Firefox AMO metadata must be a JSON object');
+    }
+    if (
+      metadata.version != null &&
+      (typeof metadata.version !== 'object' || Array.isArray(metadata.version))
+    ) {
+      throw Error('Firefox AMO version metadata must be a JSON object');
+    }
+    return metadata;
   }
 }

--- a/src/utils/config-schema.ts
+++ b/src/utils/config-schema.ts
@@ -207,7 +207,7 @@ export const FirefoxAddonStoreV5Options = object({
   amoMetadataFile: meta(optional(nonempty(string())), {
     path: 'firefox.amoMetadataFile',
     description:
-      'Path to a JSON file containing AMO listing and version metadata',
+      'Path to JSON with AMO add-on edit fields at the top level and version create fields under "version": https://mozilla.github.io/addons-server/topics/api/addons.html#edit and https://mozilla.github.io/addons-server/topics/api/addons.html#version-create',
   }),
   sourcesZip: meta(optional(nonempty(string())), {
     path: 'firefox.sourcesZip',

--- a/src/utils/config-schema.ts
+++ b/src/utils/config-schema.ts
@@ -222,7 +222,7 @@ Example:
 \`\`\`jsonc
 {
   "version": {
-    // Version-specific fields go in the "version" field.
+    // Version-specific fields go in the "version" field
     // https://mozilla.github.io/addons-server/topics/api/addons.html#version-create
     "release_notes": "...",
   },

--- a/src/utils/config-schema.ts
+++ b/src/utils/config-schema.ts
@@ -24,6 +24,7 @@ import type { DeepPartial } from './types';
 export interface MetaStruct<T> extends Struct<T> {
   '~meta': {
     description: string;
+    extendedDescription?: string;
     path: string;
     note?: string;
   };
@@ -31,12 +32,18 @@ export interface MetaStruct<T> extends Struct<T> {
 
 function meta<T>(
   struct: Struct<T>,
-  options: { path: string; description: string; note?: string },
+  options: {
+    path: string;
+    description: string;
+    extendedDescription?: string;
+    note?: string;
+  },
 ): MetaStruct<T> {
   const s = struct as MetaStruct<T>;
   s['~meta'] = {
     path: options.path,
     description: options.description,
+    extendedDescription: options.extendedDescription,
     note: options.note,
   };
   return s;
@@ -207,7 +214,24 @@ export const FirefoxAddonStoreV5Options = object({
   amoMetadataFile: meta(optional(nonempty(string())), {
     path: 'firefox.amoMetadataFile',
     description:
-      'Path to JSON with AMO add-on edit fields at the top level and version create fields under "version": https://mozilla.github.io/addons-server/topics/api/addons.html#edit and https://mozilla.github.io/addons-server/topics/api/addons.html#version-create',
+      'See: https://github.com/aklinker1/publish-browser-extension/blob/main/docs/config-reference.md#firefoxamometadatafile',
+    extendedDescription: `Path to a JSON file with metadata to update.
+
+Example:
+
+\`\`\`jsonc
+{
+  "version": {
+    // Version-specific fields go in the "version" field.
+    // https://mozilla.github.io/addons-server/topics/api/addons.html#version-create
+    "release_notes": "...",
+  },
+  // General addon fields go in the root
+  // https://mozilla.github.io/addons-server/topics/api/addons.html#edit
+  "description": "...",
+}
+\`\`\`
+`,
   }),
   sourcesZip: meta(optional(nonempty(string())), {
     path: 'firefox.sourcesZip',

--- a/src/utils/config-schema.ts
+++ b/src/utils/config-schema.ts
@@ -204,6 +204,11 @@ export const FirefoxAddonStoreV5Options = object({
     path: 'firefox.zip',
     description: 'Path to extension zip to upload',
   }),
+  amoMetadataFile: meta(optional(nonempty(string())), {
+    path: 'firefox.amoMetadataFile',
+    description:
+      'Path to a JSON file containing AMO listing and version metadata',
+  }),
   sourcesZip: meta(optional(nonempty(string())), {
     path: 'firefox.sourcesZip',
     description: 'Path to sources zip to upload',

--- a/src/utils/config-schema.ts
+++ b/src/utils/config-schema.ts
@@ -230,8 +230,7 @@ Example:
   // https://mozilla.github.io/addons-server/topics/api/addons.html#edit
   "description": "...",
 }
-\`\`\`
-`,
+\`\`\``,
   }),
   sourcesZip: meta(optional(nonempty(string())), {
     path: 'firefox.sourcesZip',

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -44,6 +44,8 @@ export interface CustomEnv {
   EDGE_SKIP_SUBMIT_REVIEW: string | undefined;
   /** Path to extension zip to upload */
   EDGE_ZIP: string | undefined;
+  /** Path to a JSON file containing AMO listing and version metadata */
+  FIREFOX_AMO_METADATA_FILE: string | undefined;
   /** The channel to publish to, "listed" or "unlisted" */
   FIREFOX_CHANNEL: string | undefined;
   /** Comma-separated list of compatible applications, e.g. "firefox,android" - "firefox" for compatibility with Firefox desktop apps, "android" for Firefox Android apps */

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -44,7 +44,7 @@ export interface CustomEnv {
   EDGE_SKIP_SUBMIT_REVIEW: string | undefined;
   /** Path to extension zip to upload */
   EDGE_ZIP: string | undefined;
-  /** Path to JSON with AMO add-on edit fields at the top level and version create fields under "version": https://mozilla.github.io/addons-server/topics/api/addons.html#edit and https://mozilla.github.io/addons-server/topics/api/addons.html#version-create */
+  /** See: https://github.com/aklinker1/publish-browser-extension/blob/main/docs/config-reference.md#firefoxamometadatafile */
   FIREFOX_AMO_METADATA_FILE: string | undefined;
   /** The channel to publish to, "listed" or "unlisted" */
   FIREFOX_CHANNEL: string | undefined;

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -61,7 +61,6 @@ export interface CustomEnv {
    *   "description": "...",
    * }
    * ```
-   *
    */
   FIREFOX_AMO_METADATA_FILE: string | undefined;
   /** The channel to publish to, "listed" or "unlisted" */

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -44,7 +44,25 @@ export interface CustomEnv {
   EDGE_SKIP_SUBMIT_REVIEW: string | undefined;
   /** Path to extension zip to upload */
   EDGE_ZIP: string | undefined;
-  /** See: https://github.com/aklinker1/publish-browser-extension/blob/main/docs/config-reference.md#firefoxamometadatafile */
+  /**
+   * Path to a JSON file with metadata to update.
+   *
+   * Example:
+   *
+   * ```jsonc
+   * {
+   *   "version": {
+   *     // Version-specific fields go in the "version" field.
+   *     // https://mozilla.github.io/addons-server/topics/api/addons.html#version-create
+   *     "release_notes": "...",
+   *   },
+   *   // General addon fields go in the root
+   *   // https://mozilla.github.io/addons-server/topics/api/addons.html#edit
+   *   "description": "...",
+   * }
+   * ```
+   *
+   */
   FIREFOX_AMO_METADATA_FILE: string | undefined;
   /** The channel to publish to, "listed" or "unlisted" */
   FIREFOX_CHANNEL: string | undefined;

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -52,7 +52,7 @@ export interface CustomEnv {
    * ```jsonc
    * {
    *   "version": {
-   *     // Version-specific fields go in the "version" field.
+   *     // Version-specific fields go in the "version" field
    *     // https://mozilla.github.io/addons-server/topics/api/addons.html#version-create
    *     "release_notes": "...",
    *   },

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -44,7 +44,7 @@ export interface CustomEnv {
   EDGE_SKIP_SUBMIT_REVIEW: string | undefined;
   /** Path to extension zip to upload */
   EDGE_ZIP: string | undefined;
-  /** Path to a JSON file containing AMO listing and version metadata */
+  /** Path to JSON with AMO add-on edit fields at the top level and version create fields under "version": https://mozilla.github.io/addons-server/topics/api/addons.html#edit and https://mozilla.github.io/addons-server/topics/api/addons.html#version-create */
   FIREFOX_AMO_METADATA_FILE: string | undefined;
   /** The channel to publish to, "listed" or "unlisted" */
   FIREFOX_CHANNEL: string | undefined;


### PR DESCRIPTION
Adds `--firefox-amo-metadata-file` with matching config and environment variable support.

Listing fields are updated before the version is created, and version fields are submitted with the upload. Source archives continue to use the multipart endpoint.

Closes #69

Tested with `bun test`, `bun run check`, and `bun run build`.