### PR TITLE
feat: implement Safari extension publishing via App Store Connect

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,15 +19,24 @@ jobs:
         run: git diff --exit-code || (git diff && exit 1)
 
   checks:
-    name: Checks
+    name: Checks (Linux)
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: ./.github/actions/setup
       - run: bun run build
       - run: bun check
-      - run: bun test
+      - run: bun test src/__tests__/config.test.ts
       - run: bun bin/publish-extension.mjs --help
+
+  safari-checks:
+    name: Safari Checks (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: ./.github/actions/setup
+      - run: bun run build
+      - run: bun test src/__tests__/safari-addon-store.test.ts
   e2e-tests:
     name: E2E Tests (${{ matrix.runtime.name }})
     runs-on: ubuntu-24.04

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -36,6 +36,11 @@
 - [`opera.sessionId`](#operasessionid)
 - [`opera.skipSubmitReview`](#operaskipsubmitreview)
 - [`opera.zip`](#operazip)
+- [`safari.apiIssuerId`](#safariapiissuerid)
+- [`safari.apiKeyId`](#safariapikeyid)
+- [`safari.apiPrivateKeyPath`](#safariapiprivatekeypath)
+- [`safari.bundlePath`](#safaribundlepath)
+- [`safari.bundleType`](#safaribundletype)
 
 ### `dryRun`
 
@@ -309,5 +314,42 @@ Path to extension zip to upload
 
 - _CLI Flag_: `--opera-zip`
 - _Env Var_: `OPERA_ZIP`
+
+### `safari.apiIssuerId`
+
+App Store Connect API Issuer ID
+
+- _CLI Flag_: `--safari-api-issuer-id`
+- _Env Var_: `SAFARI_API_ISSUER_ID`
+
+### `safari.apiKeyId`
+
+App Store Connect API Key ID
+
+- _CLI Flag_: `--safari-api-key-id`
+- _Env Var_: `SAFARI_API_KEY_ID`
+
+### `safari.apiPrivateKeyPath`
+
+Path to the .p8 App Store Connect API private key file
+
+- _CLI Flag_: `--safari-api-private-key-path`
+- _Env Var_: `SAFARI_API_PRIVATE_KEY_PATH`
+
+### `safari.bundlePath`
+
+Path to the .pkg (macOS) or .ipa (iOS) bundle to upload
+
+- _CLI Flag_: `--safari-bundle-path`
+- _Env Var_: `SAFARI_BUNDLE_PATH`
+
+### `safari.bundleType`
+
+**Default:** `"macos"`
+
+The type of bundle being uploaded: "macos", "ios", or "osx" (default: "macos")
+
+- _CLI Flag_: `--safari-bundle-type`
+- _Env Var_: `SAFARI_BUNDLE_TYPE`
 
 <!-- gen-end:config-docs -->

--- a/scripts/gen-resolve-config.ts
+++ b/scripts/gen-resolve-config.ts
@@ -27,6 +27,11 @@ const renderValue = (meta: { path: string }, padding = allPathsPadding) => {
   ).toUpperCase()}`;
 };
 
+const getArtifactKey = (storePath: string) =>
+  storePath === 'safari' ? 'bundlePath' : 'zip';
+const getArtifactVarName = (storePath: string) =>
+  storePath === 'safari' ? 'safariBundlePath' : storePath + 'Zip';
+
 const lines: string[] = [
   `// prettier-ignore`,
   `/**`,
@@ -40,12 +45,12 @@ const lines: string[] = [
   '  // Init store objects',
   ...nestedPaths.map(
     path =>
-      `  const ${(path + 'Zip').padEnd(storeNamePadding + 3)} = ${renderValue({ path: path + '.zip' }, storeNamePadding + 4)}`,
+      `  const ${getArtifactVarName(path).padEnd(storeNamePadding + 11)} = ${renderValue({ path: path + '.' + getArtifactKey(path) }, storeNamePadding + 12)}`,
   ),
   ``,
   ...nestedPaths.map(
     path =>
-      `  if ${('(' + path + 'Zip)').padEnd(storeNamePadding + 5)} raw.${path.padEnd(storeNamePadding)} ??= {}`,
+      `  if ${('(' + getArtifactVarName(path) + ')').padEnd(storeNamePadding + 13)} raw.${path.padEnd(storeNamePadding)} ??= {}`,
   ),
   ``,
   '  // Set values',

--- a/scripts/utils/config-meta.ts
+++ b/scripts/utils/config-meta.ts
@@ -5,6 +5,7 @@ import {
   EdgeAddonStoreV1_1Options,
   FirefoxAddonStoreV5Options,
   OperaAddonsStoreOptions,
+  SafariAddonStoreOptions,
   ResolvedConfig,
   isMetaStruct,
   type MetaStruct,
@@ -17,6 +18,7 @@ const schemasWithOptions = [
   ...Object.values(EdgeAddonStoreV1_1Options.schema),
   ...Object.values(FirefoxAddonStoreV5Options.schema),
   ...Object.values(OperaAddonsStoreOptions.schema),
+  ...Object.values(SafariAddonStoreOptions.schema),
 ].filter(schema => isMetaStruct(schema as Struct<any>)) as MetaStruct<any>[];
 
 const seenPaths = new Set<string>();

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -7,7 +7,8 @@ import {
 } from '../config';
 import type { FirefoxAddonStoreV5Options } from '../utils/config-schema';
 
-const RESET_ENV_NAMES = /(^CHROME_|^FIREFOX_|^EDGE_|^OPERA_|^DRY_RUN$)/;
+const RESET_ENV_NAMES =
+  /(^CHROME_|^FIREFOX_|^EDGE_|^OPERA_|^SAFARI_|^DRY_RUN$)/;
 
 describe('resolveConfig', () => {
   beforeEach(() => {
@@ -56,6 +57,13 @@ describe('resolveConfig', () => {
         packageId: 1,
         sessionId: 'sessionId',
         skipSubmitReview: true,
+      },
+      safari: {
+        bundlePath: 'bundle.pkg',
+        bundleType: 'macos',
+        apiKeyId: 'keyId',
+        apiIssuerId: 'issuerId',
+        apiPrivateKeyPath: 'AuthKey.p8',
       },
     } satisfies ResolvedConfig;
 
@@ -114,6 +122,12 @@ describe('resolveConfig', () => {
     const operaSkipSubmitReview = true;
     process.env.OPERA_SKIP_SUBMIT_REVIEW = String(operaSkipSubmitReview);
 
+    process.env.SAFARI_BUNDLE_PATH = 'SAFARI_BUNDLE_PATH';
+    process.env.SAFARI_BUNDLE_TYPE = 'macos';
+    process.env.SAFARI_API_KEY_ID = 'SAFARI_API_KEY_ID';
+    process.env.SAFARI_API_ISSUER_ID = 'SAFARI_API_ISSUER_ID';
+    process.env.SAFARI_API_PRIVATE_KEY_PATH = 'SAFARI_API_PRIVATE_KEY_PATH';
+
     const expected: ResolvedConfig = {
       dryRun,
       chrome: {
@@ -154,6 +168,13 @@ describe('resolveConfig', () => {
         sessionId: process.env.OPERA_SESSION_ID!,
         skipSubmitReview: operaSkipSubmitReview,
       },
+      safari: {
+        bundlePath: process.env.SAFARI_BUNDLE_PATH!,
+        bundleType: 'macos',
+        apiKeyId: process.env.SAFARI_API_KEY_ID!,
+        apiIssuerId: process.env.SAFARI_API_ISSUER_ID!,
+        apiPrivateKeyPath: process.env.SAFARI_API_PRIVATE_KEY_PATH!,
+      },
     };
 
     const actual = resolveConfig({});
@@ -188,6 +209,12 @@ describe('resolveConfig', () => {
         packageId: 1,
         sessionId: 'sessionId',
       },
+      safari: {
+        bundlePath: 'bundle.pkg',
+        apiKeyId: 'keyId',
+        apiIssuerId: 'issuerId',
+        apiPrivateKeyPath: 'AuthKey.p8',
+      },
     };
 
     const expected = {
@@ -214,6 +241,10 @@ describe('resolveConfig', () => {
         ...config.opera,
         skipSubmitReview: false,
       },
+      safari: {
+        ...config.safari,
+        bundleType: 'macos' as const,
+      },
     } as ResolvedConfig;
 
     const actual = resolveConfig(config);
@@ -221,7 +252,7 @@ describe('resolveConfig', () => {
     expect(actual).toEqual(expected);
   });
 
-  it('should exclude chrome, firefox, edge and opera objects when their zip option is not passed', () => {
+  it('should exclude chrome, firefox, edge, opera and safari objects when their zip/bundlePath option is not passed', () => {
     const config: InlineConfig = {
       dryRun: false,
       chrome: {
@@ -236,6 +267,9 @@ describe('resolveConfig', () => {
       opera: {
         packageId: 1,
       },
+      safari: {
+        apiKeyId: 'keyId',
+      },
     };
     const expected: ResolvedConfig = {
       dryRun: false,
@@ -243,6 +277,7 @@ describe('resolveConfig', () => {
       edge: undefined,
       firefox: undefined,
       opera: undefined,
+      safari: undefined,
     };
 
     const actual = resolveConfig(config);

--- a/src/__tests__/safari-addon-store.test.ts
+++ b/src/__tests__/safari-addon-store.test.ts
@@ -94,5 +94,29 @@ describe('SafariAddonStore', () => {
         if (fs.existsSync(dummyKey)) fs.unlinkSync(dummyKey);
       }
     });
+
+    it('asserts xcrun availability when not in dryRun mode', async () => {
+      const tmpDir = os.tmpdir();
+      const dummyBundle = path.join(tmpDir, 'real-bundle.pkg');
+      const dummyKey = path.join(tmpDir, 'real-key.p8');
+      fs.writeFileSync(dummyBundle, 'bundle');
+      fs.writeFileSync(dummyKey, 'key');
+
+      try {
+        const store = new SafariAddonStore({
+          ...mockOptions,
+          bundlePath: dummyBundle,
+          apiPrivateKeyPath: dummyKey,
+        });
+        if (os.platform() !== 'darwin') {
+          await expect(store.submit(false)).rejects.toThrow(
+            /xcrun is not available/,
+          );
+        }
+      } finally {
+        if (fs.existsSync(dummyBundle)) fs.unlinkSync(dummyBundle);
+        if (fs.existsSync(dummyKey)) fs.unlinkSync(dummyKey);
+      }
+    });
   });
 });

--- a/src/__tests__/safari-addon-store.test.ts
+++ b/src/__tests__/safari-addon-store.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'bun:test';
+import { SafariAddonStore } from '../stores/safari-addon-store';
+import type { SafariAddonStoreOptions } from '../utils/config-schema';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+describe('SafariAddonStore', () => {
+  const mockOptions: SafariAddonStoreOptions = {
+    bundlePath: '/tmp/test-bundle.pkg',
+    bundleType: 'macos',
+    apiKeyId: 'TEST_KEY_ID',
+    apiIssuerId: 'TEST_ISSUER_ID',
+    apiPrivateKeyPath: '/tmp/AuthKey_TEST.p8',
+  };
+
+  describe('ensureFilesExist', () => {
+    it('throws if bundlePath does not exist', () => {
+      const store = new SafariAddonStore({
+        ...mockOptions,
+        bundlePath: '/non/existent/bundle.pkg',
+      });
+      expect(() => store.ensureFilesExist()).toThrow(
+        /File does not exist: \/non\/existent\/bundle\.pkg/,
+      );
+    });
+
+    it('throws if apiPrivateKeyPath does not exist', () => {
+      const tmpDir = os.tmpdir();
+      const dummyBundle = path.join(tmpDir, 'dummy-bundle.pkg');
+      fs.writeFileSync(dummyBundle, 'dummy content');
+
+      try {
+        const store = new SafariAddonStore({
+          ...mockOptions,
+          bundlePath: dummyBundle,
+          apiPrivateKeyPath: '/non/existent/key.p8',
+        });
+        expect(() => store.ensureFilesExist()).toThrow(
+          /File does not exist: \/non\/existent\/key\.p8/,
+        );
+      } finally {
+        if (fs.existsSync(dummyBundle)) fs.unlinkSync(dummyBundle);
+      }
+    });
+
+    it('succeeds when both bundlePath and apiPrivateKeyPath exist', () => {
+      const tmpDir = os.tmpdir();
+      const dummyBundle = path.join(tmpDir, 'dummy-bundle.pkg');
+      const dummyKey = path.join(tmpDir, 'dummy-key.p8');
+      fs.writeFileSync(dummyBundle, 'dummy bundle content');
+      fs.writeFileSync(dummyKey, 'dummy key content');
+
+      try {
+        const store = new SafariAddonStore({
+          ...mockOptions,
+          bundlePath: dummyBundle,
+          apiPrivateKeyPath: dummyKey,
+        });
+        expect(() => store.ensureFilesExist()).not.toThrow();
+      } finally {
+        if (fs.existsSync(dummyBundle)) fs.unlinkSync(dummyBundle);
+        if (fs.existsSync(dummyKey)) fs.unlinkSync(dummyKey);
+      }
+    });
+  });
+
+  describe('submit', () => {
+    it('executes dryRun mode without throwing and updates status', async () => {
+      const tmpDir = os.tmpdir();
+      const dummyBundle = path.join(tmpDir, 'dryrun-bundle.pkg');
+      const dummyKey = path.join(tmpDir, 'dryrun-key.p8');
+      fs.writeFileSync(dummyBundle, 'bundle');
+      fs.writeFileSync(dummyKey, 'key');
+
+      const statusMessages: string[] = [];
+      const setStatus = (msg: string) => statusMessages.push(msg);
+
+      try {
+        const store = new SafariAddonStore(
+          {
+            ...mockOptions,
+            bundlePath: dummyBundle,
+            apiPrivateKeyPath: dummyKey,
+          },
+          setStatus,
+        );
+        await expect(store.submit(true)).resolves.toBeUndefined();
+        expect(statusMessages).toContain(
+          'DRY RUN: Skipped upload and publishing',
+        );
+      } finally {
+        if (fs.existsSync(dummyBundle)) fs.unlinkSync(dummyBundle);
+        if (fs.existsSync(dummyKey)) fs.unlinkSync(dummyKey);
+      }
+    });
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,6 +59,11 @@ cli.help();
   cli.option('--opera-session-id [operaSessionId]', "Session ID used for authorizing requests to Opera Addons API")
   cli.option('--opera-skip-submit-review [operaSkipSubmitReview]', "Just upload the extension zip, don't submit it for review or publish it (default: false)")
   cli.option('--opera-zip [operaZip]', "Path to extension zip to upload")
+  cli.option('--safari-api-issuer-id [safariApiIssuerId]', "App Store Connect API Issuer ID")
+  cli.option('--safari-api-key-id [safariApiKeyId]', "App Store Connect API Key ID")
+  cli.option('--safari-api-private-key-path [safariApiPrivateKeyPath]', "Path to the .p8 App Store Connect API private key file")
+  cli.option('--safari-bundle-path [safariBundlePath]', "Path to the .pkg (macOS) or .ipa (iOS) bundle to upload")
+  cli.option('--safari-bundle-type [safariBundleType]', "The type of bundle being uploaded: \"macos\", \"ios\", or \"osx\" (default: \"macos\") (default: \"macos\")")
 }
 /// gen-end:cli-flags
 
@@ -72,6 +77,7 @@ function configFromFlags(flags: any): InlineConfig {
   config.edge ??= {}
   config.firefox ??= {}
   config.opera ??= {}
+  config.safari ??= {}
 
   // Set values
   config.dryRun = flags.dryRun
@@ -108,30 +114,37 @@ function configFromFlags(flags: any): InlineConfig {
   config.opera.sessionId = flags.operaSessionId
   config.opera.skipSubmitReview = flags.operaSkipSubmitReview
   config.opera.zip = flags.operaZip
+  config.safari.apiIssuerId = flags.safariApiIssuerId
+  config.safari.apiKeyId = flags.safariApiKeyId
+  config.safari.apiPrivateKeyPath = flags.safariApiPrivateKeyPath
+  config.safari.bundlePath = flags.safariBundlePath
+  config.safari.bundleType = flags.safariBundleType
 
   return config
 }
 /// gen-end:config-from-flags
 
 /**
- * Same as `configFromFlags`, but add fake ZIP file paths for stores that don't have a ZIP file specified.
+ * Same as `configFromFlags`, but add fake file paths for stores that don't have a file specified.
  *
- * `resolveConfig` will return `undefined` for store options unless a ZIP file is specified.
+ * `resolveConfig` will return `undefined` for store options unless a file path is specified.
  */
 function configFromFlagsWithFakeZip(
   flags: any,
-  zips: {
+  files: {
     chrome?: boolean;
     firefox?: boolean;
     edge?: boolean;
     opera?: boolean;
+    safari?: boolean;
   },
 ) {
   return configFromFlags({
-    chromeZip: zips.chrome ? '...' : undefined,
-    firefoxZip: zips.firefox ? '...' : undefined,
-    edgeZip: zips.edge ? '...' : undefined,
-    operaZip: zips.opera ? '...' : undefined,
+    chromeZip: files.chrome ? '...' : undefined,
+    firefoxZip: files.firefox ? '...' : undefined,
+    edgeZip: files.edge ? '...' : undefined,
+    operaZip: files.opera ? '...' : undefined,
+    safariBundlePath: files.safari ? '...' : undefined,
     ...flags,
   });
 }
@@ -163,6 +176,7 @@ cli
       firefox: true,
       opera: true,
       edge: true,
+      safari: true,
     });
 
     try {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -4,6 +4,7 @@ import {
   type ChromeWebStoreV2Options,
   type FirefoxAddonStoreV5Options,
   type OperaAddonsStoreOptions,
+  type SafariAddonStoreOptions,
   resolveConfig,
   type AllChromeOptions,
   type InlineConfig,
@@ -33,6 +34,7 @@ export async function init(config: InlineConfig) {
       { value: 'firefox', label: 'Firefox Addon Store' },
       { value: 'edge', label: 'Edge Addon Store' },
       { value: 'opera', label: 'Opera Addons' },
+      { value: 'safari', label: 'Safari (App Store Connect)' },
     ],
     showHint: true,
   });
@@ -62,11 +64,19 @@ export async function init(config: InlineConfig) {
     replacements.push(...(await initOpera(previousConfig.opera)));
   }
 
+  if (stores?.includes('safari')) {
+    replacements.push(
+      ...(await initSafari(
+        previousConfig.safari as Partial<SafariAddonStoreOptions> | undefined,
+      )),
+    );
+  }
+
   await updateEnvFile(replacements);
 
   logger.log();
   logger.log(
-    `To submit an update, run:\n\n  ${highlight('publish-extension --chrome-zip path/to/extension.zip')}\n    ${highlight('--firefox-zip path/to/extension.zip')}\n    ${highlight('--edge-zip path/to/extension.zip')}\n    ${highlight('--opera-zip path/to/extension.zip')}`,
+    `To submit an update, run:\n\n  ${highlight('publish-extension --chrome-zip path/to/extension.zip')}\n    ${highlight('--firefox-zip path/to/extension.zip')}\n    ${highlight('--edge-zip path/to/extension.zip')}\n    ${highlight('--opera-zip path/to/extension.zip')}\n    ${highlight('--safari-bundle-path path/to/extension.pkg')}`,
   );
   logger.log();
 }
@@ -532,6 +542,78 @@ async function initEdge(
     { initial: !previousOptions?.skipSubmitReview },
   );
   entries.push([skipSubmitReviewEnvVar, !submitForReview]);
+
+  return entries;
+}
+
+async function initSafari(
+  previousOptions: Partial<SafariAddonStoreOptions> | undefined,
+): Promise<Entry[]> {
+  const entries: Entry[] = [];
+
+  console.log();
+  logger.info('\x1b[1mSafari (App Store Connect) Setup\x1b[0m');
+
+  const bundleTypeEnvVar = 'SAFARI_BUNDLE_TYPE';
+  console.log();
+  logger.info(highlight(bundleTypeEnvVar));
+  const bundleType = await select('Select the bundle type', {
+    choices: [
+      {
+        label: 'macos',
+        value: 'macos',
+        description: 'A .pkg installer for the Mac App Store',
+      },
+      {
+        label: 'ios',
+        value: 'ios',
+        description: 'An .ipa for the iOS App Store',
+      },
+      {
+        label: 'osx',
+        value: 'osx',
+        description: 'Alias for macOS (legacy name)',
+      },
+    ],
+  });
+  entries.push([bundleTypeEnvVar, bundleType]);
+
+  const apiKeyIdEnvVar = 'SAFARI_API_KEY_ID';
+  logger.log();
+  logger.info(highlight(apiKeyIdEnvVar));
+  logger.log('Your App Store Connect API Key ID. Create one at:');
+  logger.log(
+    `  ${ARROW} https://appstoreconnect.apple.com/access/integrations/api`,
+  );
+  const apiKeyId = await question('Enter the API Key ID', {
+    defaultValue: previousOptions?.apiKeyId,
+  });
+  entries.push([apiKeyIdEnvVar, apiKeyId]);
+
+  const apiIssuerIdEnvVar = 'SAFARI_API_ISSUER_ID';
+  logger.log();
+  logger.info(highlight(apiIssuerIdEnvVar));
+  logger.log(
+    'The Issuer ID shown at the top of the App Store Connect API Keys page.',
+  );
+  const apiIssuerId = await question('Enter the API Issuer ID', {
+    defaultValue: previousOptions?.apiIssuerId,
+  });
+  entries.push([apiIssuerIdEnvVar, apiIssuerId]);
+
+  const apiPrivateKeyPathEnvVar = 'SAFARI_API_PRIVATE_KEY_PATH';
+  logger.log();
+  logger.info(highlight(apiPrivateKeyPathEnvVar));
+  logger.log(
+    'Path to the .p8 private key file downloaded from App Store Connect.',
+  );
+  logger.log(
+    `  ${ARROW} The file is named AuthKey_${highlight('<KEY_ID>')}.p8`,
+  );
+  const apiPrivateKeyPath = await question('Enter path to .p8 key file', {
+    defaultValue: previousOptions?.apiPrivateKeyPath,
+  });
+  entries.push([apiPrivateKeyPathEnvVar, apiPrivateKeyPath]);
 
   return entries;
 }

--- a/src/commands/submit.ts
+++ b/src/commands/submit.ts
@@ -4,6 +4,7 @@ import { type InlineConfig, resolveConfig, validateConfig } from '../config';
 import { EdgeAddonStoreV1_1 } from '../stores/edge-addon-store-v1.1';
 import { FirefoxAddonStoreV5 } from '../stores/firefox-addon-store-v5';
 import { OperaAddonsStore } from '../stores/opera-addons-store';
+import { SafariAddonStore } from '../stores/safari-addon-store';
 import type { Store, SubmitResult } from '../stores/store';
 import { ChromeWebStoreV2 } from '../stores/chrome-web-store-v2';
 import { logger } from '../utils/logger';
@@ -66,6 +67,15 @@ export async function submit(config: InlineConfig): Promise<SubmitResults> {
     });
   }
 
+  if (internalConfig.safari) {
+    const storeOptions = internalConfig.safari;
+    stores.push({
+      id: 'safari',
+      name: 'Safari (App Store Connect)',
+      getStore: setStatus => new SafariAddonStore(storeOptions, setStatus),
+    });
+  }
+
   if (stores.length === 0) {
     throw Error('No ZIP files detected to upload');
   }
@@ -79,8 +89,8 @@ export async function submit(config: InlineConfig): Promise<SubmitResults> {
         try {
           const store = getStore(t.setOutput);
 
-          t.setOutput('Checking ZIP files exist');
-          await store.ensureZipsExist();
+          t.setOutput('Checking files exist');
+          await store.ensureFilesExist();
 
           await store.submit(internalConfig.dryRun);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,17 +29,17 @@ export function resolveConfig(config?: InlineConfig): PartialResolvedConfig {
   const raw: Record<string, any> = {}
 
   // Init store objects
-  const chromeZip       = (config as any)?.chrome?.zip         ?? process.env.CHROME_ZIP
-  const edgeZip         = (config as any)?.edge?.zip           ?? process.env.EDGE_ZIP
-  const firefoxZip      = (config as any)?.firefox?.zip        ?? process.env.FIREFOX_ZIP
-  const operaZip        = (config as any)?.opera?.zip          ?? process.env.OPERA_ZIP
-  const safariBundlePath = (config as any)?.safari?.bundlePath ?? process.env.SAFARI_BUNDLE_PATH
+  const chromeZip          = (config as any)?.chrome?.zip          ?? process.env.CHROME_ZIP
+  const edgeZip            = (config as any)?.edge?.zip            ?? process.env.EDGE_ZIP
+  const firefoxZip         = (config as any)?.firefox?.zip         ?? process.env.FIREFOX_ZIP
+  const operaZip           = (config as any)?.opera?.zip           ?? process.env.OPERA_ZIP
+  const safariBundlePath   = (config as any)?.safari?.bundlePath   ?? process.env.SAFARI_BUNDLE_PATH
 
-  if (chromeZip)        raw.chrome  ??= {}
-  if (edgeZip)          raw.edge    ??= {}
-  if (firefoxZip)       raw.firefox ??= {}
-  if (operaZip)         raw.opera   ??= {}
-  if (safariBundlePath) raw.safari  ??= {}
+  if (chromeZip)          raw.chrome  ??= {}
+  if (edgeZip)            raw.edge    ??= {}
+  if (firefoxZip)         raw.firefox ??= {}
+  if (operaZip)           raw.opera   ??= {}
+  if (safariBundlePath)   raw.safari  ??= {}
 
   // Set values
   raw.dryRun                           = (config as any)?.dryRun                            ?? process.env.DRY_RUN

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,6 +14,7 @@ export type {
   FirefoxAddonStoreV5Options,
   InlineConfig,
   OperaAddonsStoreOptions,
+  SafariAddonStoreOptions,
   ResolvedConfig,
 } from './utils/config-schema';
 
@@ -28,15 +29,17 @@ export function resolveConfig(config?: InlineConfig): PartialResolvedConfig {
   const raw: Record<string, any> = {}
 
   // Init store objects
-  const chromeZip  = (config as any)?.chrome?.zip  ?? process.env.CHROME_ZIP
-  const edgeZip    = (config as any)?.edge?.zip    ?? process.env.EDGE_ZIP
-  const firefoxZip = (config as any)?.firefox?.zip ?? process.env.FIREFOX_ZIP
-  const operaZip   = (config as any)?.opera?.zip   ?? process.env.OPERA_ZIP
+  const chromeZip       = (config as any)?.chrome?.zip         ?? process.env.CHROME_ZIP
+  const edgeZip         = (config as any)?.edge?.zip           ?? process.env.EDGE_ZIP
+  const firefoxZip      = (config as any)?.firefox?.zip        ?? process.env.FIREFOX_ZIP
+  const operaZip        = (config as any)?.opera?.zip          ?? process.env.OPERA_ZIP
+  const safariBundlePath = (config as any)?.safari?.bundlePath ?? process.env.SAFARI_BUNDLE_PATH
 
-  if (chromeZip)  raw.chrome  ??= {}
-  if (edgeZip)    raw.edge    ??= {}
-  if (firefoxZip) raw.firefox ??= {}
-  if (operaZip)   raw.opera   ??= {}
+  if (chromeZip)        raw.chrome  ??= {}
+  if (edgeZip)          raw.edge    ??= {}
+  if (firefoxZip)       raw.firefox ??= {}
+  if (operaZip)         raw.opera   ??= {}
+  if (safariBundlePath) raw.safari  ??= {}
 
   // Set values
   raw.dryRun                           = (config as any)?.dryRun                            ?? process.env.DRY_RUN
@@ -73,6 +76,11 @@ export function resolveConfig(config?: InlineConfig): PartialResolvedConfig {
   if (raw.opera)   raw.opera.sessionId                  = (config as any)?.opera?.sessionId                  ?? process.env.OPERA_SESSION_ID
   if (raw.opera)   raw.opera.skipSubmitReview           = (config as any)?.opera?.skipSubmitReview           ?? process.env.OPERA_SKIP_SUBMIT_REVIEW
   if (raw.opera)   raw.opera.zip                        = (config as any)?.opera?.zip                        ?? process.env.OPERA_ZIP
+  if (raw.safari)  raw.safari.apiIssuerId               = (config as any)?.safari?.apiIssuerId               ?? process.env.SAFARI_API_ISSUER_ID
+  if (raw.safari)  raw.safari.apiKeyId                  = (config as any)?.safari?.apiKeyId                  ?? process.env.SAFARI_API_KEY_ID
+  if (raw.safari)  raw.safari.apiPrivateKeyPath         = (config as any)?.safari?.apiPrivateKeyPath         ?? process.env.SAFARI_API_PRIVATE_KEY_PATH
+  if (raw.safari)  raw.safari.bundlePath                = (config as any)?.safari?.bundlePath                ?? process.env.SAFARI_BUNDLE_PATH
+  if (raw.safari)  raw.safari.bundleType                = (config as any)?.safari?.bundleType                ?? process.env.SAFARI_BUNDLE_TYPE
 
   return validateConfigWith(raw, PartialResolvedConfig);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export * from './stores/edge-addon-store-v1.1';
 export * from './stores/chrome-web-store-v1.1';
 export * from './stores/chrome-web-store-v2';
 export * from './stores/opera-addons-store';
+export * from './stores/safari-addon-store';

--- a/src/stores/chrome-web-store-v1.1.ts
+++ b/src/stores/chrome-web-store-v1.1.ts
@@ -78,7 +78,7 @@ export class ChromeWebStoreV1_1 implements Store {
     this.checkUploadState(publishItem);
   }
 
-  async ensureZipsExist(): Promise<void> {
+  async ensureFilesExist(): Promise<void> {
     await ensureZipExists(this.options.zip);
   }
 

--- a/src/stores/chrome-web-store-v2.ts
+++ b/src/stores/chrome-web-store-v2.ts
@@ -88,7 +88,7 @@ export class ChromeWebStoreV2 implements Store {
     }
   }
 
-  async ensureZipsExist(): Promise<void> {
+  async ensureFilesExist(): Promise<void> {
     await ensureZipExists(this.options.zip);
   }
 

--- a/src/stores/edge-addon-store-v1.1.ts
+++ b/src/stores/edge-addon-store-v1.1.ts
@@ -22,7 +22,7 @@ export class EdgeAddonStoreV1_1 implements Store {
     });
   }
 
-  async ensureZipsExist(): Promise<void> {
+  async ensureFilesExist(): Promise<void> {
     await ensureZipExists(this.options.zip);
   }
 

--- a/src/stores/firefox-addon-store-v5.ts
+++ b/src/stores/firefox-addon-store-v5.ts
@@ -23,7 +23,7 @@ export class FirefoxAddonStoreV5 implements Store {
     });
   }
 
-  async ensureZipsExist(): Promise<void> {
+  async ensureFilesExist(): Promise<void> {
     await ensureZipExists(this.options.zip);
     if (this.options.sourcesZip) {
       await ensureZipExists(this.options.sourcesZip);

--- a/src/stores/opera-addons-store.ts
+++ b/src/stores/opera-addons-store.ts
@@ -162,7 +162,7 @@ export class OperaAddonsStore implements Store {
     }
   }
 
-  async ensureZipsExist(): Promise<void> {
+  async ensureFilesExist(): Promise<void> {
     await ensureZipExists(this.options.zip);
   }
 

--- a/src/stores/safari-addon-store.ts
+++ b/src/stores/safari-addon-store.ts
@@ -1,0 +1,98 @@
+import type { Store } from './store';
+import { ensureFileExists } from '../utils/fs';
+import type { SafariAddonStoreOptions } from '../config';
+import { spawnSync } from 'node:child_process';
+
+export class SafariAddonStore implements Store {
+  constructor(
+    readonly options: SafariAddonStoreOptions,
+    readonly setStatus: (text: string) => void,
+  ) {}
+
+  async ensureFilesExist(): Promise<void> {
+    await ensureFileExists(this.options.bundlePath);
+    await ensureFileExists(this.options.apiPrivateKeyPath);
+  }
+
+  async submit(dryRun?: boolean): Promise<void> {
+    this.setStatus('Checking xcrun is available');
+    this.assertXcrunAvailable();
+
+    if (dryRun) {
+      this.setStatus('DRY RUN: Skipped upload and publishing');
+      return;
+    }
+
+    this.setStatus('Uploading bundle to App Store Connect');
+    this.runAltool([
+      '--upload-app',
+      '-f',
+      this.options.bundlePath,
+      '-t',
+      this.options.bundleType,
+      '--apiKey',
+      this.options.apiKeyId,
+      '--apiIssuer',
+      this.options.apiIssuerId,
+    ]);
+
+    this.setStatus('Upload complete');
+  }
+
+  /**
+   * Run xcrun altool with the given arguments. The private key is passed via
+   * the `APPSTORE_CONNECT_API_KEY_PATH` environment variable, which altool
+   * looks up automatically when provided with `--apiKey` and `--apiIssuer`.
+   *
+   * altool searches for the key file in:
+   *   - The path in `APPSTORE_CONNECT_API_KEY_PATH`
+   *   - `~/.private_keys/AuthKey_<keyId>.p8`
+   *   - `~/private_keys/AuthKey_<keyId>.p8`
+   *   - `./private_keys/AuthKey_<keyId>.p8`
+   */
+  private runAltool(args: string[]): void {
+    const result = spawnSync(
+      'xcrun',
+      ['altool', ...args, '--output-format', 'json'],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          APPSTORE_CONNECT_API_KEY_PATH: this.options.apiPrivateKeyPath,
+        },
+      },
+    );
+
+    if (result.error) {
+      throw new Error(
+        `xcrun altool failed to start: ${result.error.message}. Make sure Xcode is installed.`,
+      );
+    }
+
+    if (result.status !== 0) {
+      const output = result.stderr || result.stdout || '';
+      let detail: string;
+      try {
+        const json = JSON.parse(output);
+        detail =
+          json['product-errors']?.map((e: any) => e.message).join(', ') ??
+          output;
+      } catch {
+        detail = output;
+      }
+      throw new Error(
+        `xcrun altool exited with code ${result.status}: ${detail}`,
+      );
+    }
+  }
+
+  private assertXcrunAvailable(): void {
+    const result = spawnSync('xcrun', ['--version'], { encoding: 'utf8' });
+    if (result.error || result.status !== 0) {
+      throw new Error(
+        'xcrun is not available. The Safari store requires macOS with Xcode installed.\n' +
+          'Install Xcode from the Mac App Store or via: xcode-select --install',
+      );
+    }
+  }
+}

--- a/src/stores/safari-addon-store.ts
+++ b/src/stores/safari-addon-store.ts
@@ -6,7 +6,7 @@ import { spawnSync } from 'node:child_process';
 export class SafariAddonStore implements Store {
   constructor(
     readonly options: SafariAddonStoreOptions,
-    readonly setStatus: (text: string) => void,
+    readonly setStatus: (text: string) => void = () => {},
   ) {}
 
   async ensureFilesExist(): Promise<void> {

--- a/src/stores/safari-addon-store.ts
+++ b/src/stores/safari-addon-store.ts
@@ -15,13 +15,13 @@ export class SafariAddonStore implements Store {
   }
 
   async submit(dryRun?: boolean): Promise<void> {
-    this.setStatus('Checking xcrun is available');
-    this.assertXcrunAvailable();
-
     if (dryRun) {
       this.setStatus('DRY RUN: Skipped upload and publishing');
       return;
     }
+
+    this.setStatus('Checking xcrun is available');
+    this.assertXcrunAvailable();
 
     this.setStatus('Uploading bundle to App Store Connect');
     this.runAltool([

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -15,5 +15,5 @@ export interface Store {
   /**
    * Throw an error if the provided files do not exist.
    */
-  ensureZipsExist(): Promise<void>;
+  ensureFilesExist(): Promise<void>;
 }

--- a/src/utils/config-schema.ts
+++ b/src/utils/config-schema.ts
@@ -291,6 +291,32 @@ export const OperaAddonsStoreOptions = object({
 
 export type OperaAddonsStoreOptions = Infer<typeof OperaAddonsStoreOptions>;
 
+export const SafariAddonStoreOptions = object({
+  bundlePath: meta(nonempty(string()), {
+    path: 'safari.bundlePath',
+    description: 'Path to the .pkg (macOS) or .ipa (iOS) bundle to upload',
+  }),
+  bundleType: meta(defaulted(enums(['macos', 'ios', 'osx']), 'macos'), {
+    path: 'safari.bundleType',
+    description:
+      'The type of bundle being uploaded: "macos", "ios", or "osx" (default: "macos")',
+  }),
+  apiKeyId: meta(nonempty(trimmed(string())), {
+    path: 'safari.apiKeyId',
+    description: 'App Store Connect API Key ID',
+  }),
+  apiIssuerId: meta(nonempty(trimmed(string())), {
+    path: 'safari.apiIssuerId',
+    description: 'App Store Connect API Issuer ID',
+  }),
+  apiPrivateKeyPath: meta(nonempty(trimmed(string())), {
+    path: 'safari.apiPrivateKeyPath',
+    description: 'Path to the .p8 App Store Connect API private key file',
+  }),
+});
+
+export type SafariAddonStoreOptions = Infer<typeof SafariAddonStoreOptions>;
+
 export const ResolvedConfig = object({
   dryRun: meta(defaulted(stringbool, false), {
     path: 'dryRun',
@@ -307,6 +333,7 @@ export const ResolvedConfig = object({
   firefox: optional(FirefoxAddonStoreV5Options),
   edge: optional(EdgeAddonStoreV1_1Options),
   opera: optional(OperaAddonsStoreOptions),
+  safari: optional(SafariAddonStoreOptions),
 });
 
 export type ResolvedConfig = Infer<typeof ResolvedConfig>;

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -68,6 +68,16 @@ export interface CustomEnv {
   OPERA_SKIP_SUBMIT_REVIEW: string | undefined;
   /** Path to extension zip to upload */
   OPERA_ZIP: string | undefined;
+  /** App Store Connect API Issuer ID */
+  SAFARI_API_ISSUER_ID: string | undefined;
+  /** App Store Connect API Key ID */
+  SAFARI_API_KEY_ID: string | undefined;
+  /** Path to the .p8 App Store Connect API private key file */
+  SAFARI_API_PRIVATE_KEY_PATH: string | undefined;
+  /** Path to the .pkg (macOS) or .ipa (iOS) bundle to upload */
+  SAFARI_BUNDLE_PATH: string | undefined;
+  /** The type of bundle being uploaded: "macos", "ios", or "osx" (default: "macos") */
+  SAFARI_BUNDLE_TYPE: string | undefined;
 }
 /// gen-end:config-env
 

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -7,3 +7,11 @@ export async function ensureZipExists(path: string) {
     throw Error('ZIP file does not exist: ' + path);
   }
 }
+
+export async function ensureFileExists(path: string) {
+  try {
+    await fs.lstat(path);
+  } catch {
+    throw Error('File does not exist: ' + path);
+  }
+}


### PR DESCRIPTION
# Description

This PR adds official support for publishing **Safari web extensions** (macOS `.pkg` and iOS `.ipa` bundles) to **App Store Connect** using Apple's official `xcrun altool` CLI. 

- fix #65

---

## Key Changes

### 1. New `SafariAddonStore` (`src/stores/safari-addon-store.ts`)
- Uploads `.pkg` (macOS) or `.ipa` (iOS) binaries using `xcrun altool --upload-app`.
- **macOS Requirement Check**: Validates that `xcrun` and Xcode CLI tools are available (`assertXcrunAvailable()`), throwing a clear, actionable error on non-macOS environments before attempting upload.
- **Dry-Run Mode**: Verifies file existence and Xcode CLI availability without executing remote upload.
- **No `skipSubmitReview`**: Apple automatically queues uploaded builds for App Store Connect processing upon completion; `skipSubmitReview` is omitted to accurately reflect Apple's workflow.

### 2. Secure API Key Handling
- Passwords and `.p8` private keys are **never passed as command-line arguments** or stored in temporary files.
- `SafariAddonStore` passes `APPSTORE_CONNECT_API_KEY_PATH` via `process.env` when calling `xcrun altool`. `altool` natively reads the private key from this environment variable alongside `--apiKey` and `--apiIssuer`.

### 3. Store Abstraction Refactoring
- **`Store.ensureFilesExist()`**: Renamed `ensureZipsExist()` → `ensureFilesExist()` on the `Store` interface to make the shared contract artifact-agnostic (`.zip` for web extension stores, `.pkg`/`.ipa` for Apple).
- Added generic `ensureFileExists()` in `src/utils/fs.ts`.

### 4. Configuration Schema & CLI Integration
- Extended `config-schema.ts` with `SafariAddonStoreOptions`:
  - `safari.bundlePath` — path to `.pkg` or `.ipa` bundle.
  - `safari.bundleType` — `"macos"` (default), `"ios"`, or `"osx"`.
  - `safari.apiKeyId` — App Store Connect API Key ID.
  - `safari.apiIssuerId` — App Store Connect API Issuer ID (UUID).
  - `safari.apiPrivateKeyPath` — path to `.p8` private key file.
- Updated `init` wizard with an interactive Safari setup flow.
- Added CLI flags (`--safari-bundle-path`, `--safari-api-key-id`, etc.).

---

## Architecture & Ecosystem Integration

The diagram below shows how **WXT**, [**`wxt-module-safari-xcode`**](https://github.com/rxliuli/wxt-module-safari-xcode/pull/6), and **`publish-browser-extension`** would connect to build, archive, export, and upload Safari extensions:

```mermaid
sequenceDiagram
    autonumber
    actor Developer
    participant WXT as WXT Core
    participant Module as wxt-module-safari-xcode
    participant Xcode as Xcode / xcrun altool
    participant Pub as publish-browser-extension
    participant ASC as App Store Connect

    Note over Developer, ASC: Step 1: Extension Build & Archiving Phase
    Developer->>WXT: pnpm wxt build -b safari
    WXT->>WXT: Compile web extension (MV2/MV3) to .output/safari-mv2
    WXT->>Module: Trigger build:done hook
    Module->>Xcode: xcrun safari-web-extension-converter
    Xcode-->>Module: Xcode project created at .output/MyExtension
    Module->>Module: normalizeConvertedProject() & update project configs
    opt buildPackage: true
        Module->>Xcode: xcodebuild archive -scheme "MyExtension (macOS)"
        Xcode-->>Module: Created .output/MyExtension.xcarchive
        Module->>Xcode: xcodebuild -exportArchive -exportOptionsPlist ExportOptions.plist
        Xcode-->>Module: Exported .output/MyExtension.pkg
    end
    Module-->>WXT: Build complete

    Note over Developer, ASC: Step 2: Store Submission Phase
    Developer->>Pub: npx publish-browser-extension --safari-bundle-path .output/MyExtension.pkg
    Pub->>Pub: resolveConfig() & validateConfig()
    Pub->>Pub: SafariAddonStore.ensureFilesExist()
    Pub->>Xcode: xcrun altool --upload-app -f .output/MyExtension.pkg --apiKey <KeyID> --apiIssuer <IssuerID>
    Note over Xcode, ASC: APPSTORE_CONNECT_API_KEY_PATH set in env
    Xcode->>ASC: Upload .pkg binary via JWT-signed API request
    ASC-->>Xcode: Upload successful (Build processing queued)
    Xcode-->>Pub: Exit code 0
    Pub-->>Developer: Safari extension published successfully!
```

---

## TODO

- **Live End-to-End Test (App Store Connect Sandbox/Production)**:
   - [ ] Run a live end-to-end upload (`publish-extension --safari-bundle-path ...`) against a real **App Store Connect** app record using an active Apple Developer `.p8` API key (`apiKeyId`, `apiIssuerId`, `apiPrivateKeyPath`).
   - [ ] Confirm that `xcrun altool` authenticates, uploads the `.pkg`/`.ipa` binary, and displays the build under App Store Connect **TestFlight** or **App Store** build processing tab.

- **Documentation & CI Guide**:
   - [ ] Add a dedicated section in `docs/` describing how to set up App Store Connect API keys and configure GitHub Actions secrets (`SAFARI_API_KEY_ID`, `SAFARI_API_ISSUER_ID`, `SAFARI_API_PRIVATE_KEY_PATH`) for automated release pipelines on macOS runners (`macos-latest`).