### PR TITLE
fix(init): Better handling of newline chars in CWS private key

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -265,10 +265,13 @@ async function initChromeV2(
   );
   entries.push([serviceAccountClientEmailEnvVar, serviceAccountClientEmail]);
 
-  const serviceAccountPrivateKey = await question(
+  let serviceAccountPrivateKey = await question(
     `Enter the ${highlight('private_key')} (copy the JSON value, minus the surrounding quotes, keeping the "\\n" characters as-is)`,
     { defaultValue: previousOptions?.serviceAccountPrivateKey },
   );
+  serviceAccountPrivateKey = serviceAccountPrivateKey
+    .replaceAll('\\n', '\n') // Convert typed "\n" to real newlines
+    .trim(); // Remove trailing slashes
   entries.push([serviceAccountPrivateKeyEnvVar, serviceAccountPrivateKey]);
 
   const skipSubmitReviewEnvVar = 'CHROME_SKIP_SUBMIT_REVIEW';

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -265,11 +265,10 @@ async function initChromeV2(
   );
   entries.push([serviceAccountClientEmailEnvVar, serviceAccountClientEmail]);
 
-  let serviceAccountPrivateKey = await question(
+  const serviceAccountPrivateKey = await question(
     `Enter the ${highlight('private_key')} (copy the JSON value, minus the surrounding quotes, keeping the "\\n" characters as-is)`,
     { defaultValue: previousOptions?.serviceAccountPrivateKey },
   );
-  serviceAccountPrivateKey = serviceAccountPrivateKey.replaceAll('\\n', '\n');
   entries.push([serviceAccountPrivateKeyEnvVar, serviceAccountPrivateKey]);
 
   const skipSubmitReviewEnvVar = 'CHROME_SKIP_SUBMIT_REVIEW';

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -13,6 +13,7 @@ import type { CustomEnv } from '../utils/env-utils';
 import { highlight, logger } from '../utils/logger';
 import { confirm, select, multiselect, question } from '@topcli/prompts';
 import { FetchError } from '../utils/errors';
+import { setDotenvValue } from '../utils/dotenv-utils';
 
 type Entry = [key: keyof CustomEnv, value: string | number | boolean];
 
@@ -264,10 +265,11 @@ async function initChromeV2(
   );
   entries.push([serviceAccountClientEmailEnvVar, serviceAccountClientEmail]);
 
-  const serviceAccountPrivateKey = await question(
+  let serviceAccountPrivateKey = await question(
     `Enter the ${highlight('private_key')} (copy the JSON value, minus the surrounding quotes, keeping the "\\n" characters as-is)`,
     { defaultValue: previousOptions?.serviceAccountPrivateKey },
   );
+  serviceAccountPrivateKey = serviceAccountPrivateKey.replaceAll('\\n', '\n');
   entries.push([serviceAccountPrivateKeyEnvVar, serviceAccountPrivateKey]);
 
   const skipSubmitReviewEnvVar = 'CHROME_SKIP_SUBMIT_REVIEW';
@@ -540,14 +542,8 @@ async function updateEnvFile(entries: Entry[]) {
   let template = await readFile(ENV_FILE, 'utf-8').catch(() => '');
 
   for (const [name, value] of entries) {
-    const replacement = `${name}=${JSON.stringify(value)}`;
-    const pattern = new RegExp(`^${name}=.*$`, 'm');
-    const existing = template.match(pattern);
-    if (existing) {
-      template = template.replace(existing[0], replacement);
-    } else {
-      template += `\n${replacement}`;
-    }
+    if (value == null) continue;
+    template = setDotenvValue(template, name, String(value));
   }
 
   const backupFilename = `${ENV_FILE}.backup-${Date.now()}`;

--- a/src/utils/__tests__/dotenv-utils.test.ts
+++ b/src/utils/__tests__/dotenv-utils.test.ts
@@ -23,7 +23,7 @@ describe('Dotenv Utils', () => {
 
     it('should add quotes when there is a quote in the string', () => {
       const env = 'TEST="123"';
-      const expected = 'TEST="42\""';
+      const expected = 'TEST="42\\""';
 
       const actual = setDotenvValue(env, 'TEST', '42"');
 

--- a/src/utils/__tests__/dotenv-utils.test.ts
+++ b/src/utils/__tests__/dotenv-utils.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'bun:test';
+import { setDotenvValue } from '../dotenv-utils';
+
+describe('Dotenv Utils', () => {
+  describe('setDotenvValue', () => {
+    it('should replace non-quoted values', () => {
+      const env = 'TEST=123';
+      const expected = 'TEST=456';
+
+      const actual = setDotenvValue(env, 'TEST', '456');
+
+      expect(actual).toBe(expected);
+    });
+
+    it('should replace quoted values', () => {
+      const env = 'TEST="123"';
+      const expected = 'TEST=456';
+
+      const actual = setDotenvValue(env, 'TEST', '456');
+
+      expect(actual).toBe(expected);
+    });
+
+    it('should add quotes when there is a quote in the string', () => {
+      const env = 'TEST="123"';
+      const expected = 'TEST="42\""';
+
+      const actual = setDotenvValue(env, 'TEST', '42"');
+
+      expect(actual).toBe(expected);
+    });
+
+    it('should replace everything after an unclosed quote', () => {
+      const env = 'TEST_1="a\nTEST_2=b';
+      const expected = 'TEST_1=c';
+
+      const actual = setDotenvValue(env, 'TEST_1', 'c');
+
+      expect(actual).toBe(expected);
+    });
+
+    it('should include real newlines in values', () => {
+      const env = 'TEST=a';
+      const expected = 'TEST="a\nb"';
+
+      const actual = setDotenvValue(env, 'TEST', 'a\nb');
+
+      expect(actual).toBe(expected);
+    });
+
+    it('should append new values to the end of the file', () => {
+      const env = '';
+      const expected = 'TEST=123';
+
+      const actual = setDotenvValue(env, 'TEST', '123');
+
+      expect(actual).toBe(expected);
+    });
+
+    it('should maintain the trailing new line when adding a key', () => {
+      const env = 'TEST_1=123\n';
+      const expected = 'TEST_1=123\nTEST_2=456\n';
+
+      const actual = setDotenvValue(env, 'TEST_2', '456');
+
+      expect(actual).toBe(expected);
+    });
+
+    it('should maintain no trailing newline when adding a key', () => {
+      const env = 'TEST_1=123';
+      const expected = 'TEST_1=123\nTEST_2=456';
+
+      const actual = setDotenvValue(env, 'TEST_2', '456');
+
+      expect(actual).toBe(expected);
+    });
+
+    it('should ignore comments', () => {
+      const env = '# TEST=123\nTEST=456';
+      const expected = '# TEST=123\nTEST=789';
+
+      const actual = setDotenvValue(env, 'TEST', '789');
+
+      expect(actual).toBe(expected);
+    });
+  });
+});

--- a/src/utils/dotenv-utils.ts
+++ b/src/utils/dotenv-utils.ts
@@ -1,10 +1,14 @@
+const escapeChars = ['=', '\n', '$', '#', ' ', '"', "'"];
+
 export function setDotenvValue(
   dotenv: string,
   key: string,
   value: string,
 ): string {
-  const needsQuotes = value.includes('"') || value.includes('\n');
-  const wrappedValue = needsQuotes ? `"${value}"` : value;
+  const needsQuotes = escapeChars.some(char => value.includes(char));
+  const wrappedValue = needsQuotes
+    ? `"${value.replaceAll('"', '\\"')}"`
+    : value;
 
   const keyIndex = findKey(dotenv, key);
   return keyIndex == null

--- a/src/utils/dotenv-utils.ts
+++ b/src/utils/dotenv-utils.ts
@@ -1,0 +1,56 @@
+export function setDotenvValue(
+  dotenv: string,
+  key: string,
+  value: string,
+): string {
+  const needsQuotes = value.includes('"') || value.includes('\n');
+  const wrappedValue = needsQuotes ? `"${value}"` : value;
+
+  const keyIndex = findKey(dotenv, key);
+  return keyIndex == null
+    ? appendKey(dotenv, key, wrappedValue)
+    : replaceKey(dotenv, key, wrappedValue, keyIndex);
+}
+
+function findKey(dotenv: string, key: string): number | undefined {
+  const regex = new RegExp(`(^|\n)\\s*${RegExp.escape(key)}=`, 'm');
+  const match = regex.exec(dotenv);
+  if (match) return dotenv.indexOf(key, match.index);
+  return undefined;
+}
+
+function appendKey(dotenv: string, key: string, value: string): string {
+  const insert = `${key}=${value}`;
+  if (dotenv[dotenv.length - 1] === '\n') return `${dotenv}${insert}\n`;
+  if (dotenv.length === 0) return insert;
+  return dotenv + `\n${insert}`;
+}
+
+function replaceKey(
+  dotenv: string,
+  key: string,
+  wrappedValue: string,
+  keyIndex: number,
+): string {
+  const start = keyIndex + key.length + 1; // +1 for the equals sign
+  const hasQuotes = dotenv[start] === '"' || dotenv[start] === "'";
+
+  let end: number;
+  if (hasQuotes) {
+    const quote = dotenv[start];
+    end = start + 1;
+    while (
+      end < dotenv.length &&
+      dotenv[end] !== quote &&
+      dotenv[end - 1] !== '\\'
+    ) {
+      end++;
+    }
+    end++; // Stopped before the trailing quote, end should include it
+  } else {
+    end = dotenv.indexOf('\n', start);
+    if (end == -1) end = dotenv.length;
+  }
+
+  return dotenv.substring(0, start) + wrappedValue + dotenv.substring(end);
+}

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -95,3 +95,7 @@ declare global {
     interface ProcessEnv extends CustomEnv {}
   }
 }
+
+/// gen-start:config-to-env
+
+/// gen-end:config-to-env

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -95,7 +95,3 @@ declare global {
     interface ProcessEnv extends CustomEnv {}
   }
 }
-
-/// gen-start:config-to-env
-
-/// gen-end:config-to-env


### PR DESCRIPTION
Before, I was using `JSON.stringify` to convert values to their escaped versions in the `.env.submit` file. However, with the new CWS v2 private key, this didn't work, because it had newline chars.

The new approach is more involved, finding indexes and replacing substrings, but it will properly replace values spread across multiple lines.

See https://github.com/aklinker1/publish-browser-extension/issues/85#issuecomment-5240052519 for more details.