### PR TITLE
fix: fix validation error on init command

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -252,6 +252,24 @@ describe('resolveConfig', () => {
 
     expect(actual).toEqual(expected);
   });
+
+  it('should resolve config when only fake zip paths are passed', () => {
+    const config: InlineConfig = {
+      chrome: { zip: '...' },
+      firefox: { zip: '...' },
+      edge: { zip: '...' },
+      opera: { zip: '...' },
+    };
+
+    const actual = resolveConfig(config);
+
+    expect(actual).toMatchObject({
+      chrome: { zip: '...' },
+      firefox: { zip: '...' },
+      edge: { zip: '...' },
+      opera: { zip: '...' },
+    });
+  });
 });
 
 describe('validateConfig', () => {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -253,7 +253,7 @@ describe('resolveConfig', () => {
     expect(actual).toEqual(expected);
   });
 
-  it('should resolve config when only fake zip paths are passed', () => {
+  it('should resolve config without a validation error when only fake zip paths are passed', () => {
     const config: InlineConfig = {
       chrome: { zip: '...' },
       firefox: { zip: '...' },
@@ -263,12 +263,7 @@ describe('resolveConfig', () => {
 
     const actual = resolveConfig(config);
 
-    expect(actual).toMatchObject({
-      chrome: { zip: '...' },
-      firefox: { zip: '...' },
-      edge: { zip: '...' },
-      opera: { zip: '...' },
-    });
+    expect(actual).toMatchObject(config);
   });
 });
 

--- a/src/utils/config-schema.ts
+++ b/src/utils/config-schema.ts
@@ -196,15 +196,18 @@ export const ChromeWebStoreV2Options = object({
 export type ChromeWebStoreV2Options = Infer<typeof ChromeWebStoreV2Options>;
 
 /** @deprecated Will be removed October 15th, 2026, when the CWS API v1.1 is shut down. */
-export type AllChromeOptions = {
-  [
-    key in keyof ChromeWebStoreV1_1Options | keyof ChromeWebStoreV2Options
-  ]: key extends keyof ChromeWebStoreV1_1Options
-    ? ChromeWebStoreV1_1Options[key]
-    : key extends keyof ChromeWebStoreV2Options
-      ? ChromeWebStoreV2Options[key]
-      : never;
-};
+export const AllChromeOptions = object({
+  ...ChromeWebStoreV1_1Options.schema,
+  ...ChromeWebStoreV2Options.schema,
+  apiVersion: meta(optional(enums(['v1.1', 'v2'])), {
+    path: 'chrome.apiVersion',
+    description:
+      'The API version to use for the Chrome Web Store: "v1.1" or "v2"',
+  }),
+});
+
+/** @deprecated Will be removed October 15th, 2026, when the CWS API v1.1 is shut down. */
+export type AllChromeOptions = Infer<typeof AllChromeOptions>;
 
 export const FirefoxAddonStoreV5Options = object({
   zip: meta(nonempty(string()), {
@@ -339,7 +342,12 @@ export const ResolvedConfig = object({
 
 export type ResolvedConfig = Infer<typeof ResolvedConfig>;
 
-export const PartialResolvedConfig = deepPartial(ResolvedConfig);
+export const PartialResolvedConfig = deepPartial(
+  object({
+    ...ResolvedConfig.schema,
+    chrome: optional(AllChromeOptions),
+  }),
+);
 
 export type PartialResolvedConfig = Infer<typeof PartialResolvedConfig>;
 


### PR DESCRIPTION
## Description
Fixed https://github.com/aklinker1/publish-browser-extension/issues/93

## Cause
1. `init` calls `resolveConfig` with only fake zip paths.
2. `ResolvedConfig.chrome` is defined with `dynamic(...)`.
3. `deepPartial` traverses only structures with `type: "object"`. Since `type: "dynamic"` is ignored, `ResolvedConfig.chrome` is not converted to `partial`.
4. `resolveConfig` fails to validate because `PartialResolvedConfig` still has the required chrome fields.

## Side Note
Once the deprecated `ChromeWebStoreV1_1Options` is removed, `ResolvedConfig.chrome` will no longer need to use `dynamic(...)` and can simply be `optional(ChromeWebStoreV2Options)`. At that point, `AllChromeOptions` can be removed and `PartialResolvedConfig` can be reverted back to:

```ts
export const PartialResolvedConfig = deepPartial(ResolvedConfig);
```
