### PR TITLE
feat: support Chrome Web Store access tokens

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -11,9 +11,10 @@
 - [`chrome.cancelPending`](#chromecancelpending) (API v2 only)
 - [`chrome.publisherId`](#chromepublisherid) (API v2 only)
 - [`chrome.publishType`](#chromepublishtype) (API v2 only)
-- [`chrome.serviceAccountClientEmail`](#chromeserviceaccountclientemail) (API v2 only)
-- [`chrome.serviceAccountPrivateKey`](#chromeserviceaccountprivatekey) (API v2 only)
 - [`chrome.skipReview`](#chromeskipreview) (API v2 only)
+- [`chrome.serviceAccountClientEmail`](#chromeserviceaccountclientemail) (API v2 only; mutually exclusive with serviceAccountAccessToken)
+- [`chrome.serviceAccountPrivateKey`](#chromeserviceaccountprivatekey) (API v2 only; mutually exclusive with serviceAccountAccessToken)
+- [`chrome.serviceAccountAccessToken`](#chromeserviceaccountaccesstoken) (API v2 only; mutually exclusive with serviceAccountClientEmail and serviceAccountPrivateKey)
 - [`chrome.clientId`](#chromeclientid) (Deprecated: API v1.1 only)
 - [`chrome.clientSecret`](#chromeclientsecret) (Deprecated: API v1.1 only)
 - [`chrome.publishTarget`](#chromepublishtarget) (Deprecated: API v1.1 only)
@@ -110,26 +111,6 @@ Set to "STAGED_PUBLISH" to not publish the extension immediately after submissio
 - _CLI Flag_: `--chrome-publish-type`
 - _Env Var_: `CHROME_PUBLISH_TYPE`
 
-### `chrome.serviceAccountClientEmail`
-
-> [!NOTE]
-> API v2 only
-
-Client email of the service account used for authorizing requests to the Chrome Web Store
-
-- _CLI Flag_: `--chrome-service-account-client-email`
-- _Env Var_: `CHROME_SERVICE_ACCOUNT_CLIENT_EMAIL`
-
-### `chrome.serviceAccountPrivateKey`
-
-> [!NOTE]
-> API v2 only
-
-Private key of the service account used for authorizing requests to the Chrome Web Store
-
-- _CLI Flag_: `--chrome-service-account-private-key`
-- _Env Var_: `CHROME_SERVICE_ACCOUNT_PRIVATE_KEY`
-
 ### `chrome.skipReview`
 
 > [!NOTE]
@@ -139,6 +120,36 @@ Some updates, like ad-blocker rule updates, can skip the review process and be p
 
 - _CLI Flag_: `--chrome-skip-review`
 - _Env Var_: `CHROME_SKIP_REVIEW`
+
+### `chrome.serviceAccountClientEmail`
+
+> [!NOTE]
+> API v2 only; mutually exclusive with serviceAccountAccessToken
+
+Client email of the service account used for authorizing requests to the Chrome Web Store
+
+- _CLI Flag_: `--chrome-service-account-client-email`
+- _Env Var_: `CHROME_SERVICE_ACCOUNT_CLIENT_EMAIL`
+
+### `chrome.serviceAccountPrivateKey`
+
+> [!NOTE]
+> API v2 only; mutually exclusive with serviceAccountAccessToken
+
+Private key of the service account used for authorizing requests to the Chrome Web Store
+
+- _CLI Flag_: `--chrome-service-account-private-key`
+- _Env Var_: `CHROME_SERVICE_ACCOUNT_PRIVATE_KEY`
+
+### `chrome.serviceAccountAccessToken`
+
+> [!NOTE]
+> API v2 only; mutually exclusive with serviceAccountClientEmail and serviceAccountPrivateKey
+
+Short-lived OAuth 2.0 access token used for authorizing requests to the Chrome Web Store
+
+- _CLI Flag_: `--chrome-service-account-access-token`
+- _Env Var_: `CHROME_SERVICE_ACCOUNT_ACCESS_TOKEN`
 
 ### `chrome.clientId`
 

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -224,6 +224,46 @@ describe('resolveConfig', () => {
     expect(actual).toEqual(expected);
   });
 
+  it('should accept a short-lived Chrome Web Store access token', () => {
+    const config: InlineConfig = {
+      chrome: {
+        apiVersion: 'v2',
+        extensionId: 'extensionId',
+        publisherId: 'publisherId',
+        serviceAccountAccessToken: 'access-token',
+        zip: 'zip',
+      },
+    };
+
+    expect(validateConfig(resolveConfig(config)).chrome).toMatchObject({
+      serviceAccountAccessToken: 'access-token',
+    });
+  });
+
+  it('should reject incomplete or conflicting Chrome Web Store credentials', () => {
+    const base = {
+      apiVersion: 'v2' as const,
+      extensionId: 'extensionId',
+      publisherId: 'publisherId',
+      zip: 'zip',
+    };
+
+    expect(() => validateConfig({ chrome: base })).toThrow('Invalid config:');
+    expect(() =>
+      validateConfig({
+        chrome: {
+          ...base,
+          serviceAccountAccessToken: 'access-token',
+          serviceAccountClientEmail: 'client@example.com',
+          serviceAccountPrivateKey: 'private-key',
+        },
+      }),
+    ).toThrow(
+      'Invalid config:\n' +
+        '  - \u001b[36mchrome\u001b[39m: Provide either serviceAccountAccessToken or both serviceAccountClientEmail and serviceAccountPrivateKey, but not both',
+    );
+  });
+
   it('should exclude chrome, firefox, edge and opera objects when their zip option is not passed', () => {
     const config: InlineConfig = {
       dryRun: false,
@@ -264,7 +304,7 @@ describe('validateConfig', () => {
       },
     };
     expect(() => validateConfig(config)).toThrowError(
-      'Invalid config:\n  - \u001B[36mchrome.zip\u001B[39m: Expected a string, but received: undefined\n  - \u001B[36mchrome.extensionId\u001B[39m: Expected a nonempty string but received an empty one\n  - \u001B[36mchrome.publisherId\u001B[39m: Expected a string, but received: undefined\n  - \u001B[36mchrome.serviceAccountClientEmail\u001B[39m: Expected a string, but received: undefined\n  - \u001B[36mchrome.serviceAccountPrivateKey\u001B[39m: Expected a string, but received: undefined',
+      'Invalid config:\n  - \u001B[36mchrome.zip\u001B[39m: Expected a string, but received: undefined\n  - \u001B[36mchrome.extensionId\u001B[39m: Expected a nonempty string but received an empty one\n  - \u001B[36mchrome.publisherId\u001B[39m: Expected a string, but received: undefined',
     );
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,9 +34,10 @@ cli.help();
   cli.option('--chrome-cancel-pending [chromeCancelPending]', "[API v2 only] Cancel any pending review before submitting the new version (default: false)")
   cli.option('--chrome-publisher-id [chromePublisherId]', "[API v2 only] Publisher ID who owns the extension")
   cli.option('--chrome-publish-type [chromePublishType]', "[API v2 only] Set to \"STAGED_PUBLISH\" to not publish the extension immediately after submission")
-  cli.option('--chrome-service-account-client-email [chromeServiceAccountClientEmail]', "[API v2 only] Client email of the service account used for authorizing requests to the Chrome Web Store")
-  cli.option('--chrome-service-account-private-key [chromeServiceAccountPrivateKey]', "[API v2 only] Private key of the service account used for authorizing requests to the Chrome Web Store")
   cli.option('--chrome-skip-review [chromeSkipReview]', "[API v2 only] Some updates, like ad-blocker rule updates, can skip the review process and be published immediately after submission")
+  cli.option('--chrome-service-account-client-email [chromeServiceAccountClientEmail]', "[API v2 only; mutually exclusive with serviceAccountAccessToken] Client email of the service account used for authorizing requests to the Chrome Web Store")
+  cli.option('--chrome-service-account-private-key [chromeServiceAccountPrivateKey]', "[API v2 only; mutually exclusive with serviceAccountAccessToken] Private key of the service account used for authorizing requests to the Chrome Web Store")
+  cli.option('--chrome-service-account-access-token [chromeServiceAccountAccessToken]', "[API v2 only; mutually exclusive with serviceAccountClientEmail and serviceAccountPrivateKey] Short-lived OAuth 2.0 access token used for authorizing requests to the Chrome Web Store")
   cli.option('--chrome-client-id [chromeClientId]', "[Deprecated: API v1.1 only] Client ID used for authorizing requests to the Chrome Web Store")
   cli.option('--chrome-client-secret [chromeClientSecret]', "[Deprecated: API v1.1 only] Client secret used for authorizing requests to the Chrome Web Store")
   cli.option('--chrome-publish-target [chromePublishTarget]', "[Deprecated: API v1.1 only] Group to publish to, \"default\" or \"trustedTesters\"")
@@ -84,9 +85,10 @@ function configFromFlags(flags: any): InlineConfig {
   config.chrome.cancelPending = flags.chromeCancelPending
   config.chrome.publisherId = flags.chromePublisherId
   config.chrome.publishType = flags.chromePublishType
+  config.chrome.skipReview = flags.chromeSkipReview
   config.chrome.serviceAccountClientEmail = flags.chromeServiceAccountClientEmail
   config.chrome.serviceAccountPrivateKey = flags.chromeServiceAccountPrivateKey
-  config.chrome.skipReview = flags.chromeSkipReview
+  config.chrome.serviceAccountAccessToken = flags.chromeServiceAccountAccessToken
   config.chrome.clientId = flags.chromeClientId
   config.chrome.clientSecret = flags.chromeClientSecret
   config.chrome.publishTarget = flags.chromePublishTarget

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,9 +48,10 @@ export function resolveConfig(config?: InlineConfig): PartialResolvedConfig {
   if (raw.chrome)  raw.chrome.cancelPending             = (config as any)?.chrome?.cancelPending             ?? process.env.CHROME_CANCEL_PENDING
   if (raw.chrome)  raw.chrome.publisherId               = (config as any)?.chrome?.publisherId               ?? process.env.CHROME_PUBLISHER_ID
   if (raw.chrome)  raw.chrome.publishType               = (config as any)?.chrome?.publishType               ?? process.env.CHROME_PUBLISH_TYPE
+  if (raw.chrome)  raw.chrome.skipReview                = (config as any)?.chrome?.skipReview                ?? process.env.CHROME_SKIP_REVIEW
   if (raw.chrome)  raw.chrome.serviceAccountClientEmail = (config as any)?.chrome?.serviceAccountClientEmail ?? process.env.CHROME_SERVICE_ACCOUNT_CLIENT_EMAIL
   if (raw.chrome)  raw.chrome.serviceAccountPrivateKey  = (config as any)?.chrome?.serviceAccountPrivateKey  ?? process.env.CHROME_SERVICE_ACCOUNT_PRIVATE_KEY
-  if (raw.chrome)  raw.chrome.skipReview                = (config as any)?.chrome?.skipReview                ?? process.env.CHROME_SKIP_REVIEW
+  if (raw.chrome)  raw.chrome.serviceAccountAccessToken = (config as any)?.chrome?.serviceAccountAccessToken ?? process.env.CHROME_SERVICE_ACCOUNT_ACCESS_TOKEN
   if (raw.chrome)  raw.chrome.clientId                  = (config as any)?.chrome?.clientId                  ?? process.env.CHROME_CLIENT_ID
   if (raw.chrome)  raw.chrome.clientSecret              = (config as any)?.chrome?.clientSecret              ?? process.env.CHROME_CLIENT_SECRET
   if (raw.chrome)  raw.chrome.publishTarget             = (config as any)?.chrome?.publishTarget             ?? process.env.CHROME_PUBLISH_TARGET

--- a/src/stores/chrome-web-store-v2.ts
+++ b/src/stores/chrome-web-store-v2.ts
@@ -109,14 +109,17 @@ export class ChromeWebStoreV2 implements Store {
   }
 
   private async getAccessToken(): Promise<string> {
+    if (this.options.serviceAccountAccessToken)
+      return this.options.serviceAccountAccessToken;
+
     if (!this.accessTokenCache)
-      this.accessTokenCache = this.getAccessTokenNoCache();
+      this.accessTokenCache = this.generateAccessToken();
 
     const data = await this.accessTokenCache;
     return data.access_token;
   }
 
-  private async getAccessTokenNoCache(): Promise<ServiceAccountTokenResponse> {
+  private async generateAccessToken(): Promise<ServiceAccountTokenResponse> {
     const res = await fetch('https://oauth2.googleapis.com/token', {
       method: 'POST',
       headers: {
@@ -125,8 +128,8 @@ export class ChromeWebStoreV2 implements Store {
       body: new URLSearchParams({
         grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
         assertion: createGcpServiceAccountJwt(
-          this.options.serviceAccountClientEmail,
-          this.options.serviceAccountPrivateKey,
+          this.options.serviceAccountClientEmail!,
+          this.options.serviceAccountPrivateKey!,
           ['https://www.googleapis.com/auth/chromewebstore'],
         ),
       }),

--- a/src/utils/config-schema.ts
+++ b/src/utils/config-schema.ts
@@ -18,6 +18,7 @@ import {
   trimmed,
   defaulted,
   partial,
+  refine,
 } from 'superstruct';
 import type { DeepPartial } from './types';
 
@@ -145,7 +146,7 @@ export const ChromeWebStoreV1_1Options = object({
 /** @deprecated Will be removed October 15th, 2026, when the CWS API v1.1 is shut down. */
 export type ChromeWebStoreV1_1Options = Infer<typeof ChromeWebStoreV1_1Options>;
 
-export const ChromeWebStoreV2Options = object({
+const ChromeWebStoreV2OptionsShape = {
   apiVersion: meta(literal('v2'), {
     path: 'chrome.apiVersion',
     description:
@@ -157,15 +158,21 @@ export const ChromeWebStoreV2Options = object({
     note: 'API v2 only',
     description: 'Publisher ID who owns the extension',
   }),
-  serviceAccountClientEmail: meta(nonempty(trimmed(string())), {
+  serviceAccountAccessToken: meta(optional(nonempty(trimmed(string()))), {
+    path: 'chrome.serviceAccountAccessToken',
+    note: 'API v2 only; mutually exclusive with serviceAccountClientEmail and serviceAccountPrivateKey',
+    description:
+      'Short-lived OAuth 2.0 access token used for authorizing requests to the Chrome Web Store',
+  }),
+  serviceAccountClientEmail: meta(optional(nonempty(trimmed(string()))), {
     path: 'chrome.serviceAccountClientEmail',
-    note: 'API v2 only',
+    note: 'API v2 only; mutually exclusive with serviceAccountAccessToken',
     description:
       'Client email of the service account used for authorizing requests to the Chrome Web Store',
   }),
-  serviceAccountPrivateKey: meta(nonempty(trimmed(string())), {
+  serviceAccountPrivateKey: meta(optional(nonempty(trimmed(string()))), {
     path: 'chrome.serviceAccountPrivateKey',
-    note: 'API v2 only',
+    note: 'API v2 only; mutually exclusive with serviceAccountAccessToken',
     description:
       'Private key of the service account used for authorizing requests to the Chrome Web Store',
   }),
@@ -191,7 +198,18 @@ export const ChromeWebStoreV2Options = object({
     note: 'API v2 only',
     description: 'Cancel any pending review before submitting the new version',
   }),
-});
+};
+
+export const ChromeWebStoreV2Options = refine(
+  object(ChromeWebStoreV2OptionsShape),
+  'chrome-v2-authentication',
+  value =>
+    Boolean(value.serviceAccountAccessToken) !==
+      Boolean(
+        value.serviceAccountClientEmail && value.serviceAccountPrivateKey,
+      ) ||
+    'Provide either serviceAccountAccessToken or both serviceAccountClientEmail and serviceAccountPrivateKey, but not both',
+);
 
 export type ChromeWebStoreV2Options = Infer<typeof ChromeWebStoreV2Options>;
 

--- a/src/utils/env-utils.ts
+++ b/src/utils/env-utils.ts
@@ -18,12 +18,14 @@ export interface CustomEnv {
   CHROME_PUBLISHER_ID: string | undefined;
   /** [API v2 only] Set to "STAGED_PUBLISH" to not publish the extension immediately after submission */
   CHROME_PUBLISH_TYPE: string | undefined;
-  /** [API v2 only] Client email of the service account used for authorizing requests to the Chrome Web Store */
-  CHROME_SERVICE_ACCOUNT_CLIENT_EMAIL: string | undefined;
-  /** [API v2 only] Private key of the service account used for authorizing requests to the Chrome Web Store */
-  CHROME_SERVICE_ACCOUNT_PRIVATE_KEY: string | undefined;
   /** [API v2 only] Some updates, like ad-blocker rule updates, can skip the review process and be published immediately after submission */
   CHROME_SKIP_REVIEW: string | undefined;
+  /** [API v2 only; mutually exclusive with serviceAccountAccessToken] Client email of the service account used for authorizing requests to the Chrome Web Store */
+  CHROME_SERVICE_ACCOUNT_CLIENT_EMAIL: string | undefined;
+  /** [API v2 only; mutually exclusive with serviceAccountAccessToken] Private key of the service account used for authorizing requests to the Chrome Web Store */
+  CHROME_SERVICE_ACCOUNT_PRIVATE_KEY: string | undefined;
+  /** [API v2 only; mutually exclusive with serviceAccountClientEmail and serviceAccountPrivateKey] Short-lived OAuth 2.0 access token used for authorizing requests to the Chrome Web Store */
+  CHROME_SERVICE_ACCOUNT_ACCESS_TOKEN: string | undefined;
   /** [Deprecated: API v1.1 only] Client ID used for authorizing requests to the Chrome Web Store */
   CHROME_CLIENT_ID: string | undefined;
   /** [Deprecated: API v1.1 only] Client secret used for authorizing requests to the Chrome Web Store */


### PR DESCRIPTION
Closes #95

Adds support for using short-lived Chrome Web Store OAuth access tokens directly, enabling GitHub Actions Workload Identity Federation without long-lived service-account private keys.

- Preserves the existing service-account JWT flow
- Adds CLI and environment variable configuration
- Validates mutually exclusive authentication methods
- Updates reference documentation and tests